### PR TITLE
feat: print processing action name in warning logs

### DIFF
--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -96,16 +96,18 @@ func (c *Controller) parseLine(ctx context.Context, logE *logrus.Entry, line str
 		return line, nil
 	}
 
+	actionLogE := logE.WithField("action", action.Name)
+
 	switch getVersionType(action.Tag) {
 	case Empty:
-		return c.parseNoTagLine(ctx, logE, line, action)
+		return c.parseNoTagLine(ctx, actionLogE, line, action)
 	case Semver:
 		// @xxx # v3.0.0
-		return c.parseSemverTagLine(ctx, logE, line, cfg, action)
+		return c.parseSemverTagLine(ctx, actionLogE, line, cfg, action)
 	case Shortsemver:
 		// @xxx # v3
 		// @<full commit hash> # v3
-		return c.parseShortSemverTagLine(ctx, logE, line, action)
+		return c.parseShortSemverTagLine(ctx, actionLogE, line, action)
 	default:
 		return line, nil
 	}


### PR DESCRIPTION
`pinact run -u` since v1.1.0 is useful, however users can not control the tagged list in upstream.
Printed warnings are often hard for track the reason if the file contains multiple actions.

For example, I have a `lint.yml` which contains multiple linters.
Then it alerts below warning.


```
WARN[0003] get the latest version                        error="parse a version: Malformed version: wikipedia-dict-v0.4.0" pinact_version= program=pinact workflow_file=.github/workflows/lint.yml
```

We can know this is caused on https://github.com/crate-ci/typos.

```console
> gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/crate-ci/typos/tags | jq '.[].name'
"wikipedia-dict-v0.4.0"
"wikipedia-dict-v0.3.0"
"wikipedia-dict-v0.2.0"
"wikipedia-codegen-v0.4.0"
"wikipedia-codegen-v0.3.0"
"wikipedia-codegen-v0.2.0"
"varcon-v1.0.1"
"varcon-v1.0.0"
"varcon-v0.7.7"
"varcon-v0.7.6"
"varcon-v0.7.5"
"varcon-v0.7.4"
"varcon-v0.7.3"
"varcon-v0.7.2"
"varcon-v0.7.1"
"varcon-v0.7.0"
"varcon-v0.6.9"
"varcon-v0.6.8"
"varcon-v0.6.7"
"varcon-v0.6.6"
"varcon-v0.6.5"
"varcon-v0.6.4"
"varcon-v0.6.3"
"varcon-v0.6.2"
"varcon-v0.6.1"
"varcon-v0.6.0"
"varcon-v0.5.1"
"varcon-v0.5.0"
"varcon-v0.4.0"
"varcon-v0.3.0"
```

However I need to run these command for all actions in the file.

So this PR aims to add the action name in related warnings.

After

```
WARN[0002] get the latest version                        action=crate-ci/typos error="parse a version: Malformed version: wikipedia-dict-v0.4.0" pinact_version= program=pinact workflow_file=.github/workflows/lint.yml
```