### PR TITLE
fix(update): allow invalid semver

### DIFF
--- a/pkg/controller/run/controller.go
+++ b/pkg/controller/run/controller.go
@@ -22,6 +22,7 @@ func New(ctx context.Context, input *InputNew) *Controller {
 	return &Controller{
 		repositoriesService: &RepositoriesServiceImpl{
 			tags:                map[string]*ListTagsResult{},
+			releases:            map[string]*ListReleasesResult{},
 			commits:             map[string]*GetCommitSHA1Result{},
 			RepositoriesService: gh.Repositories,
 		},

--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -76,7 +76,7 @@ func (c *Controller) GetLatestVersion(ctx context.Context, logE *logrus.Entry, o
 	for _, tag := range tags {
 		v, err := version.NewVersion(tag.GetName())
 		if err != nil {
-			logerr.WithError(logE, err).Debug("parse a version")
+			logerr.WithError(logE, err).WithField("action_version", tag.GetName()).Debug("parse a version")
 		}
 		if latestSemver != nil {
 			if v.GreaterThan(latestSemver) {

--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -76,7 +76,7 @@ func (c *Controller) GetLatestVersion(ctx context.Context, logE *logrus.Entry, o
 	for _, tag := range tags {
 		v, err := version.NewVersion(tag.GetName())
 		if err != nil {
-			logerr.WithError(logE, err).Warn("parse a version")
+			logerr.WithError(logE, err).Debug("parse a version")
 		}
 		if latestSemver != nil {
 			if v.GreaterThan(latestSemver) {

--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -122,7 +122,7 @@ func (c *Controller) parseNoTagLine(ctx context.Context, logE *logrus.Entry, lin
 	// @xxx
 	if c.update {
 		// get the latest version
-		lv, _, err := c.GetLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
+		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
 		if err != nil {
 			logerr.WithError(logE, err).Warn("get the latest version")
 			return line, nil
@@ -161,7 +161,7 @@ func (c *Controller) parseSemverTagLine(ctx context.Context, logE *logrus.Entry,
 	// @xxx # v3.0.0
 	if c.update {
 		// get the latest version
-		lv, _, err := c.GetLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
+		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
 		if err != nil {
 			logerr.WithError(logE, err).Warn("get the latest version")
 			return line, nil
@@ -197,7 +197,7 @@ func (c *Controller) parseShortSemverTagLine(ctx context.Context, logE *logrus.E
 		return line, nil
 	}
 	if c.update {
-		lv, _, err := c.GetLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
+		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
 		if err != nil {
 			logerr.WithError(logE, err).Warn("get the latest version")
 			return line, nil

--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -122,7 +122,7 @@ func (c *Controller) parseNoTagLine(ctx context.Context, logE *logrus.Entry, lin
 	// @xxx
 	if c.update {
 		// get the latest version
-		lv, _, err := c.GetLatestVersion(ctx, action.RepoOwner, action.RepoName)
+		lv, _, err := c.GetLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
 		if err != nil {
 			logerr.WithError(logE, err).Warn("get the latest version")
 			return line, nil
@@ -161,7 +161,7 @@ func (c *Controller) parseSemverTagLine(ctx context.Context, logE *logrus.Entry,
 	// @xxx # v3.0.0
 	if c.update {
 		// get the latest version
-		lv, _, err := c.GetLatestVersion(ctx, action.RepoOwner, action.RepoName)
+		lv, _, err := c.GetLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
 		if err != nil {
 			logerr.WithError(logE, err).Warn("get the latest version")
 			return line, nil
@@ -197,7 +197,7 @@ func (c *Controller) parseShortSemverTagLine(ctx context.Context, logE *logrus.E
 		return line, nil
 	}
 	if c.update {
-		lv, _, err := c.GetLatestVersion(ctx, action.RepoOwner, action.RepoName)
+		lv, _, err := c.GetLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
 		if err != nil {
 			logerr.WithError(logE, err).Warn("get the latest version")
 			return line, nil

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -10,13 +10,14 @@ import (
 )
 
 type (
-	ListOptions   = github.ListOptions
-	Reference     = github.Reference
-	Response      = github.Response
-	RepositoryTag = github.RepositoryTag
-	Client        = github.Client
-	GitObject     = github.GitObject
-	Commit        = github.Commit
+	ListOptions       = github.ListOptions
+	Reference         = github.Reference
+	Response          = github.Response
+	RepositoryTag     = github.RepositoryTag
+	RepositoryRelease = github.RepositoryRelease
+	Client            = github.Client
+	GitObject         = github.GitObject
+	Commit            = github.Commit
 )
 
 func New(ctx context.Context) *Client {


### PR DESCRIPTION
Fixed a bug that `pinact run -u` can't update actions if actions' available versions include non semver.

- https://github.com/suzuki-shunsuke/pinact/pull/666#issuecomment-2564252747

## Test

.github/workflows/wc-test.yaml:

```yaml
name: test
on: workflow_call
jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - uses: crate-ci/typos@v1.28.3
```

pinact v1.1.0:

The action isn't updated.

```console
$ pinact run -u .github/workflows/wc-test.yaml 
WARN[0001] get the latest version                        error="parse a version: Malformed version: wikipedia-dict-v0.4.0" pinact_version=1.1.0 program=pinact workflow_file=.github/workflows/wc-test.yaml
```
