### PR TITLE
chore: Support .yml extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ index 84bd67a..5d92e44 100644
          with:
            path: prime-numbers
            key: ${{ runner.os }}-primes
- 
+
    actionlint:
 -    uses: suzuki-shunsuke/actionlint-workflow/.github/workflows/actionlint.yaml@v0.5.0
 +    uses: suzuki-shunsuke/actionlint-workflow/.github/workflows/actionlint.yaml@b6a5f966d4504893b2aeb60cf2b0de8946e48504 # v0.5.0
@@ -135,7 +135,7 @@ We develop GitHub Actions to pin GitHub Actions and reusable workflows by pinact
 
 ## Configuration
 
-pinact supports a configuration file `.pinact.yaml` or `.github/pinact.yaml`.
+pinact supports a configuration file `.pinact.yaml`, `.github/pinact.yaml`, `.pinact.yml` or `.github/pinact.yml`.
 You can also specify the configuration file path by the environment variable `PINACT_CONFIG` or command line option `-c`.
 
 .pinact.yaml

--- a/pkg/controller/run/config.go
+++ b/pkg/controller/run/config.go
@@ -22,7 +22,7 @@ type IgnoreAction struct {
 }
 
 func getConfigPath(fs afero.Fs) (string, error) {
-	for _, path := range []string{".pinact.yaml", ".github/pinact.yaml"} {
+	for _, path := range []string{".pinact.yaml", ".github/pinact.yaml", ".pinact.yml", ".github/pinact.yml"} {
 		f, err := afero.Exists(fs, path)
 		if err != nil {
 			return "", fmt.Errorf("check if %s exists: %w", path, err)


### PR DESCRIPTION
Signed-off-by: Takahiro Nakayama <civitaspo@gmail.com>

This Pull Request adds `.yml` as a supported configuration file extension for pinact, ensuring consistency with your other OSS that already uses `.yml`, not only `.yaml`. It simply updates the config path candidates to recognize `.yml` in addition to `.yaml`.