### PR TITLE
fix(windows): path pattern not matched on Windows

### DIFF
--- a/pkg/controller/run/search_file.go
+++ b/pkg/controller/run/search_file.go
@@ -52,7 +52,7 @@ func (c *Controller) searchFilesByConfig(logE *logrus.Entry, pwd string) ([]stri
 			return nil
 		}
 		for _, pattern := range patterns {
-			if pattern.MatchString(filePath) {
+			if pattern.MatchString(filepath.ToSlash(filePath)) {
 				files = append(files, filePath)
 				break
 			}

--- a/pkg/controller/run/search_file.go
+++ b/pkg/controller/run/search_file.go
@@ -51,8 +51,9 @@ func (c *Controller) searchFilesByConfig(logE *logrus.Entry, pwd string) ([]stri
 			}).WithError(err).Debug("get a relative path")
 			return nil
 		}
+		sp := filepath.ToSlash(filePath)
 		for _, pattern := range patterns {
-			if pattern.MatchString(filepath.ToSlash(filePath)) {
+			if pattern.MatchString(sp) {
 				files = append(files, filePath)
 				break
 			}


### PR DESCRIPTION
The current `pinact init` generates the following configuration:

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
# pinact - https://github.com/suzuki-shunsuke/pinact
files:
  - pattern: "^\\.github/workflows/.*\\.ya?ml$"
  - pattern: "^(.*/)?action\\.ya?ml$"

ignore_actions:
# - name: actions/checkout
# - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml

```

But, this pattern never matches on Windows. However, this is not due to a wrong configuration, but rather a problem with the OS path separator.
Therefore, I inserted `filepath.ToSlash` into the part that matches the regular expression and the path. Now the above setting works on Windows.