### PR TITLE
feat: Add `ignore_actions[].ref` in config

### DIFF
--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,6 +1,7 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/v2.0.4/json-schema/pinact.json
+# yaml-language-server: $schema=json-schema/pinact.json
 # pinact - https://github.com/suzuki-shunsuke/pinact
 ignore_actions:
   - name: actions/setup-java
+    ref: v3
   - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
   - name: "^peaceiris/"

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ We develop GitHub Actions to pin GitHub Actions and reusable workflows by pinact
 
 ## Configuration
 
+A configuration file is optional.
 pinact supports a configuration file `.pinact.yaml`, `.github/pinact.yaml`, `.pinact.yml` or `.github/pinact.yml`.
 You can also specify the configuration file path by the environment variable `PINACT_CONFIG` or command line option `-c`.
 
@@ -203,6 +204,8 @@ ignore_actions:
   # > Invalid ref: 68bad40844440577b33778c9f29077a3388838e9. Expected ref of the form refs/tags/vX.Y.Z
   # https://github.com/slsa-framework/slsa-github-generator/issues/722
   - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
+  - name: ^suzuki-shunsuke/
+    ref: main # optional
 ```
 
 ### `files[].pattern`

--- a/README.md
+++ b/README.md
@@ -217,6 +217,20 @@ The regular expression of target files. If files are passed via positional comma
 A regular expression to ignore actions and reusable workflows.
 Actions and reusable workflows matching the regular expression are ignored.
 
+### `ignore_actions[].ref`
+
+A regular expression to ignore actions and reusable workflows by ref.
+If not specified, any ref is ignored.
+
+> [!WARNING]
+> Ignoring actions without specifying a ref can be dangerous in certain scenarios:
+>
+> 1. If an attacker gains access to push to any branch in the repository (even non-protected branches), they could create a malicious branch with the same action name
+> 2. For organization-internal actions, ignoring without ref restriction means trusting that ALL branches of the repository are secure
+> 3. Even with organization-internal repositories, compromised credentials of a contributor could lead to backdoors in non-protected branches
+>
+> For better security, consider limiting ignored actions to specific refs (like `main` or specific version tags) that have proper review processes and branch protection rules in place.
+
 ### JSON Schema
 
 - [pinact.json](json-schema/pinact.json)

--- a/json-schema/pinact.json
+++ b/json-schema/pinact.json
@@ -44,7 +44,7 @@
         },
         "ref": {
           "type": "string",
-          "description": "A regular expression to ignore actions and reusable workflows by ref. If not specified, any ref is ignored"
+          "description": "A regular expression to ignore actions and reusable workflows by ref. If not specified"
         }
       },
       "additionalProperties": false,

--- a/json-schema/pinact.json
+++ b/json-schema/pinact.json
@@ -41,6 +41,10 @@
         "name": {
           "type": "string",
           "description": "A regular expression to ignore actions and reusable workflows"
+        },
+        "ref": {
+          "type": "string",
+          "description": "A regular expression to ignore actions and reusable workflows by ref. If not specified, any ref is ignored"
         }
       },
       "additionalProperties": false,

--- a/pkg/controller/run/config_test.go
+++ b/pkg/controller/run/config_test.go
@@ -1,0 +1,89 @@
+package run
+
+import (
+	"testing"
+)
+
+func TestIgnoreAction_Match(t *testing.T) {
+	t.Parallel()
+	data := []struct {
+		name       string
+		configName string
+		configRef  string
+		actionName string
+		actionRef  string
+		expected   bool
+	}{
+		{
+			name:       "match by name only",
+			configName: "actions/checkout",
+			configRef:  "",
+			actionName: "actions/checkout",
+			actionRef:  "main",
+			expected:   true,
+		},
+		{
+			name:       "match by name and ref",
+			configName: "actions/checkout",
+			configRef:  "main",
+			actionName: "actions/checkout",
+			actionRef:  "main",
+			expected:   true,
+		},
+		{
+			name:       "match by name but not by ref",
+			configName: "actions/checkout",
+			configRef:  "main",
+			actionName: "actions/checkout",
+			actionRef:  "develop",
+			expected:   false,
+		},
+		{
+			name:       "match by regex name",
+			configName: "^actions/.*",
+			configRef:  "",
+			actionName: "actions/checkout",
+			actionRef:  "main",
+			expected:   true,
+		},
+		{
+			name:       "match by regex ref",
+			configName: "actions/checkout",
+			configRef:  "^v\\d+\\.\\d+\\.\\d+$",
+			actionName: "actions/checkout",
+			actionRef:  "v3.5.2",
+			expected:   true,
+		},
+		{
+			name:       "match by regex ref but not match",
+			configName: "actions/checkout",
+			configRef:  "^v\\d+\\.\\d+\\.\\d+$",
+			actionName: "actions/checkout",
+			actionRef:  "main",
+			expected:   false,
+		},
+		{
+			name:       "not match by name",
+			configName: "actions/checkout",
+			configRef:  "",
+			actionName: "actions/setup-go",
+			actionRef:  "main",
+			expected:   false,
+		},
+	}
+
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			config, err := NewIgnoreAction(d.configName, d.configRef)
+			if err != nil {
+				t.Fatalf("failed to create ignore action: %v", err)
+			}
+
+			got := config.Match(d.actionName, d.actionRef)
+			if got != d.expected {
+				t.Fatalf("wanted %v, got %v", d.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/controller/run/config_test.go
+++ b/pkg/controller/run/config_test.go
@@ -1,10 +1,12 @@
-package run
+package run_test
 
 import (
 	"testing"
+
+	"github.com/suzuki-shunsuke/pinact/pkg/controller/run"
 )
 
-func TestIgnoreAction_Match(t *testing.T) {
+func TestIgnoreAction_Match(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	data := []struct {
 		name       string
@@ -75,7 +77,7 @@ func TestIgnoreAction_Match(t *testing.T) {
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
 			t.Parallel()
-			config, err := NewIgnoreAction(d.configName, d.configRef)
+			config, err := run.NewIgnoreAction(d.configName, d.configRef)
 			if err != nil {
 				t.Fatalf("failed to create ignore action: %v", err)
 			}

--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -89,7 +89,7 @@ func (c *Controller) parseLine(ctx context.Context, logE *logrus.Entry, line str
 	logE = logE.WithField("action", action.Name+"@"+action.Version)
 
 	for _, ignoreAction := range c.cfg.IgnoreActions {
-		if ignoreAction.Match(action.Name) {
+		if ignoreAction.Match(action.Name, action.Version) {
 			logE.Debug("ignore the action")
 			return "", nil
 		}


### PR DESCRIPTION
## Why

Currently, `ignore_actions` only checks the action name, which can be dangerous in certain scenarios:

1. For organization-internal actions, ignoring without ref restriction means trusting that ALL branches of the repository are secure
2. If an attacker gains access to push to any branch in the repository (even non-protected branches), they could create a malicious branch with the same action name
3. Even with organization-internal repositories, compromised credentials of a contributor could lead to backdoors in non-protected branches

For example, if you have an internal action like this:
```yaml
- uses: a-trusted-org/a-trusted-repo@main
```

And you ignore it without ref restriction:
```yaml
ignore_actions:
  - name: a-trusted-org/a-trusted-repo
```

Then any branch in the repository could be used, potentially containing malicious code. However, if you restrict it to `main`:
```yaml
ignore_actions:
  - name: a-trusted-org/a-trusted-repo
    ref: main # Trusted branch
```

You ensure that only the `main` branch (which typically has proper review processes and branch protection rules) is trusted.

## What

1. Added `ref` field to `IgnoreAction` struct
   - Optional field that accepts a regular expression
   - If not specified, any ref is ignored (backward compatible)

2. Updated `Match` method to check both name and ref
   - First checks if the name matches
   - If `ref` is specified, also checks if the ref matches
   - If `ref` is not specified, returns true if name matches (backward compatible)

3. Updated JSON Schema to include the new field

4. Added documentation in README.md
   - Added description of the new field
   - Added security warning about the risks of not specifying ref
   - Added example showing how to use the new field

5. Added unit tests for `IgnoreAction`

## Breaking Changes

None. This change is backward compatible as the `ref` field is optional.
