### PR TITLE
feat: support files[].pattern, ignore_actions[].name and ref format

### DIFF
--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -4,6 +4,7 @@ ignore_actions:
   - name: actions/setup-java
     name_format: fixed_string
     ref: v3
+    ref_format: fixed_string
   - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
     name_format: fixed_string
   - name: "^peaceiris/"

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -2,6 +2,9 @@
 # pinact - https://github.com/suzuki-shunsuke/pinact
 ignore_actions:
   - name: actions/setup-java
+    name_format: fixed_string
     ref: v3
   - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
+    name_format: fixed_string
   - name: "^peaceiris/"
+    name_format: regexp

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=json-schema/pinact.json
 # pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
 ignore_actions:
   - name: actions/setup-java
     name_format: fixed_string

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ ignore_actions:
   # https://github.com/slsa-framework/slsa-github-generator/issues/722
   - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
     name_format: fixed_string
-    ref: "v\\d+\.\\d+\.\\d+"
+    ref: "v\\d+\\.\\d+\\.\\d+"
     ref_format: regexp
   - name: actions/*
     name_format: glob

--- a/README.md
+++ b/README.md
@@ -196,33 +196,50 @@ e.g.
 
 ```yaml
 files:
-  - pattern: "^\\.github/workflows/.*\\.ya?ml$"
-  - pattern: "^(.*/)?action\\.ya?ml$"
+  - pattern: .github/workflows/*.yml
+  - pattern: .github/workflows/*.yaml
+  - pattern: .github/actions/*/action.yml
+  - pattern: .github/actions/*/action.yaml
 
 ignore_actions:
   # slsa-framework/slsa-github-generator doesn't support pinning version
   # > Invalid ref: 68bad40844440577b33778c9f29077a3388838e9. Expected ref of the form refs/tags/vX.Y.Z
   # https://github.com/slsa-framework/slsa-github-generator/issues/722
   - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
+    name_format: fixed_string
+    ref: "v\\d+\.\\d+\.\\d+"
+    ref_format: regexp
+  - name: actions/*
+    name_format: glob
   - name: ^suzuki-shunsuke/
-    ref: ^main$ # optional
+    name_format: regexp
+    ref: main
+    ref_format: fixed_string
 ```
 
 ### `files[].pattern`
 
-The regular expression of target files. If files are passed via positional command line arguments, the configuration is ignored.
+A glob pattern of target files. If files are passed via positional command line arguments, the configuration is ignored.
 
 ### `ignore_actions[].name`
 
 > [!TIP]
 > As of pinact v1.3.0, regular expressions are supported. [#798](https://github.com/suzuki-shunsuke/pinact/pull/798)
 
-A regular expression to ignore actions and reusable workflows.
-Actions and reusable workflows matching the regular expression are ignored.
+> [!TIP]
+> As of pinact v3.0.0, a fixed string, a glob pattern, and a regular expression are supported. [#848](https://github.com/suzuki-shunsuke/pinact/pull/848)
+
+This is required. A pattern of ignored actions and reusable workflows.
+
+### `ignore_actions[].name_format`
+
+This is required. A format of `name`.
+This must be `fixed_string`, `glob`, or `regexp`.
 
 ### `ignore_actions[].ref`
 
-A regular expression to ignore actions and reusable workflows by ref.
+This is optional.
+A pattern of ignored action versions.
 If not specified, any ref is ignored.
 
 > [!WARNING]
@@ -233,6 +250,12 @@ If not specified, any ref is ignored.
 > 3. Even with organization-internal repositories, compromised credentials of a contributor could lead to backdoors in non-protected branches
 >
 > For better security, consider limiting ignored actions to specific refs (like `^main$` or specific version tags) that have proper review processes and branch protection rules in place.
+
+### `ignore_actions[].ref_format`
+
+This is required if `ref` is specified.
+A format of `ref`.
+This must be `fixed_string`, `glob`, or `regexp`.
 
 ### JSON Schema
 

--- a/README.md
+++ b/README.md
@@ -209,8 +209,6 @@ ignore_actions:
     name_format: fixed_string
     ref: "v\\d+\\.\\d+\\.\\d+"
     ref_format: regexp
-  - name: actions/*
-    name_format: glob
   - name: ^suzuki-shunsuke/
     name_format: regexp
     ref: main

--- a/cmd/gen-jsonschema/main.go
+++ b/cmd/gen-jsonschema/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/suzuki-shunsuke/gen-go-jsonschema/jsonschema"
-	"github.com/suzuki-shunsuke/pinact/pkg/controller/run"
+	"github.com/suzuki-shunsuke/pinact/pkg/config"
 )
 
 func main() {
@@ -15,7 +15,7 @@ func main() {
 }
 
 func core() error {
-	if err := jsonschema.Write(&run.Config{}, "json-schema/pinact.json"); err != nil {
+	if err := jsonschema.Write(&config.Config{}, "json-schema/pinact.json"); err != nil {
 		return fmt.Errorf("create or update a JSON Schema: %w", err)
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/suzuki-shunsuke/pinact
 go 1.23.4
 
 require (
+	github.com/goccy/go-yaml v1.16.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v70 v70.0.0
 	github.com/hashicorp/go-version v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goccy/go-yaml v1.16.0 h1:d7m1G7A0t+logajVtklHfDYJs2Et9g3gHwdBNNFou0w=
+github.com/goccy/go-yaml v1.16.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/json-schema/pinact.json
+++ b/json-schema/pinact.json
@@ -28,12 +28,21 @@
         "pattern": {
           "type": "string",
           "description": "A regular expression of target files. If files are passed via positional command line arguments"
+        },
+        "pattern_format": {
+          "type": "string",
+          "enum": [
+            "fixed_string",
+            "glob",
+            "regexp"
+          ]
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "pattern"
+        "pattern",
+        "pattern_format"
       ]
     },
     "IgnoreAction": {
@@ -45,12 +54,29 @@
         "ref": {
           "type": "string",
           "description": "A regular expression to ignore actions and reusable workflows by ref. If not specified"
+        },
+        "name_format": {
+          "type": "string",
+          "enum": [
+            "fixed_string",
+            "glob",
+            "regexp"
+          ]
+        },
+        "ref_format": {
+          "type": "string",
+          "enum": [
+            "fixed_string",
+            "glob",
+            "regexp"
+          ]
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "name"
+        "name",
+        "name_format"
       ]
     }
   }

--- a/json-schema/pinact.json
+++ b/json-schema/pinact.json
@@ -1,10 +1,17 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/suzuki-shunsuke/pinact/pkg/controller/run/config",
+  "$id": "https://github.com/suzuki-shunsuke/pinact/pkg/config/config",
   "$ref": "#/$defs/Config",
   "$defs": {
     "Config": {
       "properties": {
+        "version": {
+          "type": "integer",
+          "enum": [
+            2,
+            3
+          ]
+        },
         "files": {
           "items": {
             "$ref": "#/$defs/File"
@@ -27,7 +34,7 @@
       "properties": {
         "pattern": {
           "type": "string",
-          "description": "A regular expression of target files. If files are passed via positional command line arguments"
+          "description": "A glob pattern of target files."
         }
       },
       "additionalProperties": false,
@@ -39,12 +46,10 @@
     "IgnoreAction": {
       "properties": {
         "name": {
-          "type": "string",
-          "description": "A regular expression to ignore actions and reusable workflows"
+          "type": "string"
         },
         "ref": {
-          "type": "string",
-          "description": "A regular expression to ignore actions and reusable workflows by ref. If not specified"
+          "type": "string"
         },
         "name_format": {
           "type": "string",

--- a/json-schema/pinact.json
+++ b/json-schema/pinact.json
@@ -28,21 +28,12 @@
         "pattern": {
           "type": "string",
           "description": "A regular expression of target files. If files are passed via positional command line arguments"
-        },
-        "pattern_format": {
-          "type": "string",
-          "enum": [
-            "fixed_string",
-            "glob",
-            "regexp"
-          ]
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "pattern",
-        "pattern_format"
+        "pattern"
       ]
     },
     "IgnoreAction": {

--- a/json-schema/pinact.json
+++ b/json-schema/pinact.json
@@ -33,8 +33,7 @@
     "File": {
       "properties": {
         "pattern": {
-          "type": "string",
-          "description": "A glob pattern of target files."
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -55,7 +54,6 @@
           "type": "string",
           "enum": [
             "fixed_string",
-            "glob",
             "regexp"
           ]
         },
@@ -63,7 +61,6 @@
           "type": "string",
           "enum": [
             "fixed_string",
-            "glob",
             "regexp"
           ]
         }
@@ -71,8 +68,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "name",
-        "name_format"
+        "name"
       ]
     }
   }

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -40,7 +40,7 @@ func (r *Runner) initAction(c *cli.Context) error {
 		Releases:            map[string]*run.ListReleasesResult{},
 		Commits:             map[string]*run.GetCommitSHA1Result{},
 		RepositoriesService: gh.Repositories,
-	}, afero.NewOsFs(), &run.ParamRun{
+	}, afero.NewOsFs(), nil, nil, &run.ParamRun{
 		WorkflowFilePaths: c.Args().Slice(),
 		ConfigFilePath:    c.String("config"),
 		PWD:               pwd,

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -1,7 +1,12 @@
 package cli
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/pinact/pkg/controller/run"
+	"github.com/suzuki-shunsuke/pinact/pkg/github"
 	"github.com/suzuki-shunsuke/pinact/pkg/log"
 	"github.com/urfave/cli/v2"
 )
@@ -25,7 +30,25 @@ $ pinact init .github/pinact.yaml
 }
 
 func (r *Runner) initAction(c *cli.Context) error {
-	ctrl := run.New(c.Context, &run.ParamRun{})
+	pwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get the current directory: %w", err)
+	}
+	gh := github.New(c.Context)
+	ctrl := run.New(&run.RepositoriesServiceImpl{
+		Tags:                map[string]*run.ListTagsResult{},
+		Releases:            map[string]*run.ListReleasesResult{},
+		Commits:             map[string]*run.GetCommitSHA1Result{},
+		RepositoriesService: gh.Repositories,
+	}, afero.NewOsFs(), &run.ParamRun{
+		WorkflowFilePaths: c.Args().Slice(),
+		ConfigFilePath:    c.String("config"),
+		PWD:               pwd,
+		IsVerify:          c.Bool("verify"),
+		Check:             c.Bool("check"),
+		Update:            c.Bool("update"),
+	})
+
 	log.SetLevel(c.String("log-level"), r.LogE)
 	configFilePath := c.Args().First()
 	if configFilePath == "" {

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -25,7 +25,7 @@ $ pinact init .github/pinact.yaml
 }
 
 func (r *Runner) initAction(c *cli.Context) error {
-	ctrl := run.New(c.Context, &run.InputNew{})
+	ctrl := run.New(c.Context, &run.ParamRun{})
 	log.SetLevel(c.String("log-level"), r.LogE)
 	configFilePath := c.Args().First()
 	if configFilePath == "" {

--- a/pkg/cli/migrate/command.go
+++ b/pkg/cli/migrate/command.go
@@ -1,0 +1,43 @@
+package migrate
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/suzuki-shunsuke/pinact/pkg/config"
+	"github.com/suzuki-shunsuke/pinact/pkg/controller/migrate"
+	"github.com/suzuki-shunsuke/pinact/pkg/log"
+	"github.com/urfave/cli/v2"
+)
+
+type Runner struct {
+	LogE *logrus.Entry
+}
+
+func New(logE *logrus.Entry) *cli.Command {
+	r := Runner{
+		LogE: logE,
+	}
+	return r.newCommand()
+}
+
+func (r *Runner) newCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "migrate",
+		Usage: "Migrate .pinact.yaml",
+		Description: `Migrate the version of .pinact.yaml
+
+$ pinact migrate
+`,
+		Action: r.action,
+	}
+}
+
+func (r *Runner) action(c *cli.Context) error {
+	log.SetLevel(c.String("log-level"), r.LogE)
+	fs := afero.NewOsFs()
+	ctrl := migrate.New(fs, config.NewFinder(fs), &migrate.Param{
+		ConfigFilePath: c.String("config"),
+	})
+
+	return ctrl.Migrate(r.LogE) //nolint:wrapcheck
+}

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/afero"
+	"github.com/suzuki-shunsuke/pinact/pkg/config"
 	"github.com/suzuki-shunsuke/pinact/pkg/controller/run"
 	"github.com/suzuki-shunsuke/pinact/pkg/github"
 	"github.com/suzuki-shunsuke/pinact/pkg/log"
@@ -53,12 +54,13 @@ func (r *Runner) runAction(c *cli.Context) error {
 	}
 
 	gh := github.New(c.Context)
+	fs := afero.NewOsFs()
 	ctrl := run.New(&run.RepositoriesServiceImpl{
 		Tags:                map[string]*run.ListTagsResult{},
 		Releases:            map[string]*run.ListReleasesResult{},
 		Commits:             map[string]*run.GetCommitSHA1Result{},
 		RepositoriesService: gh.Repositories,
-	}, afero.NewOsFs(), &run.ParamRun{
+	}, fs, config.NewFinder(fs), config.NewReader(fs), &run.ParamRun{
 		WorkflowFilePaths: c.Args().Slice(),
 		ConfigFilePath:    c.String("config"),
 		PWD:               pwd,

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/pinact/pkg/controller/run"
+	"github.com/suzuki-shunsuke/pinact/pkg/github"
 	"github.com/suzuki-shunsuke/pinact/pkg/log"
 	"github.com/urfave/cli/v2"
 )
@@ -49,7 +51,14 @@ func (r *Runner) runAction(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("get the current directory: %w", err)
 	}
-	ctrl := run.New(c.Context, &run.ParamRun{
+
+	gh := github.New(c.Context)
+	ctrl := run.New(&run.RepositoriesServiceImpl{
+		Tags:                map[string]*run.ListTagsResult{},
+		Releases:            map[string]*run.ListReleasesResult{},
+		Commits:             map[string]*run.GetCommitSHA1Result{},
+		RepositoriesService: gh.Repositories,
+	}, afero.NewOsFs(), &run.ParamRun{
 		WorkflowFilePaths: c.Args().Slice(),
 		ConfigFilePath:    c.String("config"),
 		PWD:               pwd,

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -44,20 +44,18 @@ $ pinact run .github/actions/foo/action.yaml .github/actions/bar/action.yaml
 }
 
 func (r *Runner) runAction(c *cli.Context) error {
-	ctrl := run.New(c.Context, &run.InputNew{
-		Update: c.Bool("update"),
-	})
 	log.SetLevel(c.String("log-level"), r.LogE)
 	pwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("get the current directory: %w", err)
 	}
-	param := &run.ParamRun{
+	ctrl := run.New(c.Context, &run.ParamRun{
 		WorkflowFilePaths: c.Args().Slice(),
 		ConfigFilePath:    c.String("config"),
 		PWD:               pwd,
 		IsVerify:          c.Bool("verify"),
 		Check:             c.Bool("check"),
-	}
-	return ctrl.Run(c.Context, r.LogE, param) //nolint:wrapcheck
+		Update:            c.Bool("update"),
+	})
+	return ctrl.Run(c.Context, r.LogE) //nolint:wrapcheck
 }

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/pinact/pkg/cli/migrate"
 	"github.com/suzuki-shunsuke/urfave-cli-help-all/helpall"
 	"github.com/urfave/cli/v2"
 )
@@ -54,6 +55,7 @@ func (r *Runner) Run(ctx context.Context, args ...string) error {
 			r.newInitCommand(),
 			r.newRunCommand(),
 			r.newVersionCommand(),
+			migrate.New(r.LogE),
 			helpall.New(nil),
 		},
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,14 +34,14 @@ func (f *File) Init(v int) error {
 		return errors.New("pattern is required")
 	}
 	switch v {
-	case 0, 2:
+	case 0, 2: //nolint:mnd
 		r, err := regexp.Compile(f.Pattern)
 		if err != nil {
 			return fmt.Errorf("compile pattern as a regular expression: %w", err)
 		}
 		f.patternRegexp = r
 		return nil
-	case 3:
+	case 3: //nolint:mnd
 		_, err := path.Match(f.Pattern, "a")
 		if err != nil {
 			return fmt.Errorf("parse pattern as a glob: %w", err)
@@ -81,7 +81,7 @@ func (ia *IgnoreAction) initName(v int) error {
 		return errors.New("name is required")
 	}
 	switch v {
-	case 0, 2:
+	case 0, 2: //nolint:mnd
 		switch ia.NameFormat {
 		case "", formatRegexp:
 		default:
@@ -91,7 +91,7 @@ func (ia *IgnoreAction) initName(v int) error {
 		var err error
 		ia.nameRegexp, err = initFormat(ia.Name, formatRegexp)
 		return err
-	case 3:
+	case 3: //nolint:mnd
 		if ia.NameFormat == "" {
 			return errors.New("name_format is required")
 		}
@@ -108,7 +108,7 @@ func (ia *IgnoreAction) initRef(v int) error {
 		return nil
 	}
 	switch v {
-	case 0, 2:
+	case 0, 2: //nolint:mnd
 		switch ia.RefFormat {
 		case "", formatRegexp:
 		default:
@@ -118,7 +118,7 @@ func (ia *IgnoreAction) initRef(v int) error {
 		var err error
 		ia.refRegexp, err = initFormat(ia.Ref, formatRegexp)
 		return err
-	case 3:
+	case 3: //nolint:mnd
 		if ia.RefFormat == "" {
 			return errors.New("ref_format is required if ref is specified")
 		}

--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -1,4 +1,4 @@
-package run
+package config
 
 import (
 	"testing"
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func TestController_getConfigPath(t *testing.T) {
+func Test_getConfigPath(t *testing.T) {
 	t.Parallel()
 	data := []struct {
 		name  string

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -98,7 +98,7 @@ func TestIgnoreAction_Match(t *testing.T) { //nolint:funlen
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
 			t.Parallel()
-			if err := d.ignoreAction.Init(); err != nil {
+			if err := d.ignoreAction.Init(3); err != nil {
 				t.Fatalf("failed to initialize ignore action: %v", err)
 			}
 			got, err := d.ignoreAction.Match(d.actionName, d.actionRef)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,23 +1,23 @@
-package run_test
+package config_test
 
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/pinact/pkg/controller/run"
+	"github.com/suzuki-shunsuke/pinact/pkg/config"
 )
 
 func TestIgnoreAction_Match(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	data := []struct {
 		name         string
-		ignoreAction *run.IgnoreAction
+		ignoreAction *config.IgnoreAction
 		actionName   string
 		actionRef    string
 		expected     bool
 	}{
 		{
 			name: "match by name only",
-			ignoreAction: &run.IgnoreAction{
+			ignoreAction: &config.IgnoreAction{
 				Name:       "actions/checkout",
 				NameFormat: "fixed_string",
 			},
@@ -27,7 +27,7 @@ func TestIgnoreAction_Match(t *testing.T) { //nolint:funlen
 		},
 		{
 			name: "match by name and ref",
-			ignoreAction: &run.IgnoreAction{
+			ignoreAction: &config.IgnoreAction{
 				Name:       "actions/checkout",
 				NameFormat: "fixed_string",
 				Ref:        "main",
@@ -39,7 +39,7 @@ func TestIgnoreAction_Match(t *testing.T) { //nolint:funlen
 		},
 		{
 			name: "match by name but not by ref",
-			ignoreAction: &run.IgnoreAction{
+			ignoreAction: &config.IgnoreAction{
 				Name:       "actions/checkout",
 				NameFormat: "fixed_string",
 				Ref:        "main",
@@ -51,7 +51,7 @@ func TestIgnoreAction_Match(t *testing.T) { //nolint:funlen
 		},
 		{
 			name: "match by regex name",
-			ignoreAction: &run.IgnoreAction{
+			ignoreAction: &config.IgnoreAction{
 				Name:       "^actions/.*",
 				NameFormat: "regexp",
 			},
@@ -61,7 +61,7 @@ func TestIgnoreAction_Match(t *testing.T) { //nolint:funlen
 		},
 		{
 			name: "match by regex ref",
-			ignoreAction: &run.IgnoreAction{
+			ignoreAction: &config.IgnoreAction{
 				Name:       "actions/checkout",
 				NameFormat: "fixed_string",
 				Ref:        "^v\\d+\\.\\d+\\.\\d+$",
@@ -73,7 +73,7 @@ func TestIgnoreAction_Match(t *testing.T) { //nolint:funlen
 		},
 		{
 			name: "match by regex ref but not match",
-			ignoreAction: &run.IgnoreAction{
+			ignoreAction: &config.IgnoreAction{
 				Name:       "actions/checkout",
 				NameFormat: "fixed_string",
 				Ref:        "^v\\d+\\.\\d+\\.\\d+$",
@@ -85,7 +85,7 @@ func TestIgnoreAction_Match(t *testing.T) { //nolint:funlen
 		},
 		{
 			name: "not match by name",
-			ignoreAction: &run.IgnoreAction{
+			ignoreAction: &config.IgnoreAction{
 				Name:       "actions/checkout",
 				NameFormat: "fixed_string",
 			},

--- a/pkg/controller/migrate/ast.go
+++ b/pkg/controller/migrate/ast.go
@@ -1,0 +1,135 @@
+package migrate
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/parser"
+	"github.com/sirupsen/logrus"
+)
+
+const falseStr = "false"
+
+func parseConfigAST(_ *logrus.Entry, content []byte) (string, error) {
+	file, err := parser.ParseBytes(content, parser.ParseComments)
+	if err != nil {
+		return "", fmt.Errorf("parse a workflow file as YAML: %w", err)
+	}
+	for _, doc := range file.Docs {
+		if err := parseDocAST(doc); err != nil {
+			return "", err
+		}
+	}
+	return file.String(), nil
+}
+
+func parseDocAST(doc *ast.DocumentNode) error {
+	body, ok := doc.Body.(*ast.MappingNode)
+	if !ok {
+		return errors.New("document body must be *ast.MappingNode")
+	}
+	if err := migrateIgnoreActions(body); err != nil {
+		return fmt.Errorf("migrate ignore_actions: %w", err)
+	}
+	if err := migrateVersion(body); err != nil {
+		return fmt.Errorf("migrate version: %w", err)
+	}
+	return nil
+}
+
+func migrateIgnoreActions(body *ast.MappingNode) error {
+	// ignore_actions:
+	//   - name:
+	//     name_format:
+	//     ref:
+	//     ref_format:
+	ignoreActionsNode := findNodeByKey(body.Values, "ignore_actions")
+	if ignoreActionsNode == nil {
+		return nil
+	}
+	switch seq := ignoreActionsNode.Value.(type) {
+	case *ast.SequenceNode:
+		for _, value := range seq.Values {
+			if err := migrateIgnoreAction(value); err != nil {
+				return fmt.Errorf("migrate ignore_actions: %w", err)
+			}
+		}
+		return nil
+	default:
+		return errors.New("version must be an array")
+	}
+}
+
+func migrateIgnoreAction(body ast.Node) error {
+	// name:
+	// name_format:
+	// ref:
+	// ref_format:
+	m, ok := body.(*ast.MappingNode)
+	if !ok {
+		return errors.New("ignore_action must be a mapping node")
+	}
+
+	value := map[string]any{}
+
+	nameFormatNode := findNodeByKey(m.Values, "name_format")
+	if nameFormatNode == nil {
+		value["name_format"] = "regexp"
+	}
+
+	if refNode := findNodeByKey(m.Values, "ref"); refNode != nil {
+		refFormatNode := findNodeByKey(m.Values, "ref_format")
+		if refFormatNode == nil {
+			value["ref_format"] = "regexp"
+		}
+	}
+
+	if len(value) == 0 {
+		return nil
+	}
+	node, err := yaml.ValueToNode(value)
+	if err != nil {
+		return fmt.Errorf("convert name_format to node: %w", err)
+	}
+	m.Merge(node.(*ast.MappingNode)) //nolint:forcetypeassert
+	return nil
+}
+
+func migrateVersion(body *ast.MappingNode) error {
+	// version:
+	versionNode := findNodeByKey(body.Values, "version")
+	if versionNode == nil {
+		node, err := yaml.ValueToNode(map[string]any{
+			"version": 3,
+		})
+		if err != nil {
+			return fmt.Errorf("convert version to node: %w", err)
+		}
+		body.Merge(node.(*ast.MappingNode)) //nolint:forcetypeassert
+		return nil
+	}
+
+	switch v := versionNode.Value.(type) {
+	case *ast.IntegerNode:
+		v.Token.Value = "3"
+		v.Value = 3
+		return nil
+	default:
+		return errors.New("version must be a number")
+	}
+}
+
+func findNodeByKey(values []*ast.MappingValueNode, key string) *ast.MappingValueNode {
+	for _, value := range values {
+		k, ok := value.Key.(*ast.StringNode)
+		if !ok {
+			continue
+		}
+		if k.Value == key {
+			return value
+		}
+	}
+	return nil
+}

--- a/pkg/controller/migrate/ast.go
+++ b/pkg/controller/migrate/ast.go
@@ -10,8 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const falseStr = "false"
-
 func parseConfigAST(_ *logrus.Entry, content []byte) (string, error) {
 	file, err := parser.ParseBytes(content, parser.ParseComments)
 	if err != nil {
@@ -102,7 +100,7 @@ func migrateVersion(body *ast.MappingNode) error {
 	versionNode := findNodeByKey(body.Values, "version")
 	if versionNode == nil {
 		node, err := yaml.ValueToNode(map[string]any{
-			"version": 3,
+			"version": 3, //nolint:mnd
 		})
 		if err != nil {
 			return fmt.Errorf("convert version to node: %w", err)

--- a/pkg/controller/migrate/controller.go
+++ b/pkg/controller/migrate/controller.go
@@ -10,15 +10,10 @@ type Controller struct {
 	cfg       *config.Config
 	param     *Param
 	cfgFinder ConfigFinder
-	cfgReader ConfigReader
 }
 
 type ConfigFinder interface {
 	Find(configFilePath string) (string, error)
-}
-
-type ConfigReader interface {
-	Read(cfg *config.Config, configFilePath string) error
 }
 
 type Param struct {

--- a/pkg/controller/migrate/controller.go
+++ b/pkg/controller/migrate/controller.go
@@ -1,0 +1,35 @@
+package migrate
+
+import (
+	"github.com/spf13/afero"
+	"github.com/suzuki-shunsuke/pinact/pkg/config"
+)
+
+type Controller struct {
+	fs        afero.Fs
+	cfg       *config.Config
+	param     *Param
+	cfgFinder ConfigFinder
+	cfgReader ConfigReader
+}
+
+type ConfigFinder interface {
+	Find(configFilePath string) (string, error)
+}
+
+type ConfigReader interface {
+	Read(cfg *config.Config, configFilePath string) error
+}
+
+type Param struct {
+	ConfigFilePath string
+}
+
+func New(fs afero.Fs, cfgFinder ConfigFinder, param *Param) *Controller {
+	return &Controller{
+		param:     param,
+		fs:        fs,
+		cfg:       &config.Config{},
+		cfgFinder: cfgFinder,
+	}
+}

--- a/pkg/controller/migrate/migrate.go
+++ b/pkg/controller/migrate/migrate.go
@@ -1,0 +1,83 @@
+package migrate
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/suzuki-shunsuke/pinact/pkg/config"
+	"gopkg.in/yaml.v3"
+)
+
+func (c *Controller) Migrate(logE *logrus.Entry) error {
+	// find and read .pinact.yaml
+	p, err := c.cfgFinder.Find(c.param.ConfigFilePath)
+	if err != nil {
+		return fmt.Errorf("find a configurationfile: %w", err)
+	}
+	if p == "" {
+		// if .pinact.yaml doesn't exist, return nil
+		logE.Warn("no configuration file is found")
+		return nil
+	}
+	c.param.ConfigFilePath = p
+
+	content, err := afero.ReadFile(c.fs, p)
+	if err != nil {
+		return fmt.Errorf("read a file: %w", err)
+	}
+
+	cfg := &config.Config{}
+	if err := yaml.Unmarshal(content, cfg); err != nil {
+		return fmt.Errorf("parse a config file: %w", err)
+	}
+	c.cfg = cfg
+
+	s, err := c.migrate(logE, content)
+	if err != nil {
+		return err
+	}
+	if s == "" {
+		logE.Info("configuration file isn't changed")
+		return nil
+	}
+	if err := c.edit(c.param.ConfigFilePath, s); err != nil {
+		return fmt.Errorf("edit the configuration file: %w", err)
+	}
+	return nil
+}
+
+func (c *Controller) edit(file, content string) error {
+	stat, err := c.fs.Stat(file)
+	if err != nil {
+		return fmt.Errorf("get configuration file stat: %w", err)
+	}
+	if err := afero.WriteFile(c.fs, file, []byte(content), stat.Mode()); err != nil {
+		return fmt.Errorf("write the configuration file: %w", err)
+	}
+	return nil
+}
+
+func (c *Controller) migrate(logE *logrus.Entry, content []byte) (string, error) {
+	switch c.cfg.Version {
+	case 2:
+		return c.migrateV2(logE, content)
+	case 3:
+		return "", nil
+	case 0:
+		return c.migrateEmptyVersion(logE, content)
+	default:
+		return "", fmt.Errorf("unsupported version: %d", c.cfg.Version)
+	}
+}
+
+func (c *Controller) migrateEmptyVersion(logE *logrus.Entry, content []byte) (string, error) {
+	return parseConfigAST(logE, content)
+}
+
+func (c *Controller) migrateV2(logE *logrus.Entry, content []byte) (string, error) {
+	// Add code comment
+	// Change version from 2 to 3
+	// Set name_format and ref_format
+	return parseConfigAST(logE, content)
+}

--- a/pkg/controller/migrate/migrate.go
+++ b/pkg/controller/migrate/migrate.go
@@ -60,9 +60,9 @@ func (c *Controller) edit(file, content string) error {
 
 func (c *Controller) migrate(logE *logrus.Entry, content []byte) (string, error) {
 	switch c.cfg.Version {
-	case 2:
+	case 2: //nolint:mnd
 		return c.migrateV2(logE, content)
-	case 3:
+	case 3: //nolint:mnd
 		return "", nil
 	case 0:
 		return c.migrateEmptyVersion(logE, content)

--- a/pkg/controller/run/config.go
+++ b/pkg/controller/run/config.go
@@ -41,8 +41,8 @@ func (f *File) Init() error {
 type IgnoreAction struct {
 	Name       string `json:"name" jsonschema:"description=A regular expression to ignore actions and reusable workflows"`
 	Ref        string `json:"ref,omitempty" jsonschema:"description=A regular expression to ignore actions and reusable workflows by ref. If not specified, any ref is ignored"`
-	NameFormat string `json:"name_format" jsonschema:"enum=fixed_string,enum=glob,enum=regexp"`
-	RefFormat  string `json:"ref_format,omitempty" jsonschema:"enum=fixed_string,enum=glob,enum=regexp"`
+	NameFormat string `json:"name_format" yaml:"name_format" jsonschema:"enum=fixed_string,enum=glob,enum=regexp"`
+	RefFormat  string `json:"ref_format,omitempty" yaml:"ref_format" jsonschema:"enum=fixed_string,enum=glob,enum=regexp"`
 	nameRegexp *regexp.Regexp
 	refRegexp  *regexp.Regexp
 }

--- a/pkg/controller/run/config.go
+++ b/pkg/controller/run/config.go
@@ -166,6 +166,7 @@ func (c *Controller) readConfig() error {
 			return nil
 		}
 		configFilePath = p
+		c.param.ConfigFilePath = configFilePath
 	}
 	f, err := c.fs.Open(configFilePath)
 	if err != nil {

--- a/pkg/controller/run/config.go
+++ b/pkg/controller/run/config.go
@@ -127,6 +127,10 @@ func (ia *IgnoreAction) Match(name, ref string) (bool, error) {
 		return false, nil
 	}
 
+	if ia.Ref == "" {
+		return true, nil
+	}
+
 	f, err = match(ref, ia.Ref, ia.RefFormat, ia.refRegexp)
 	if err != nil {
 		return false, fmt.Errorf("match ref: %w", err)

--- a/pkg/controller/run/config_test.go
+++ b/pkg/controller/run/config_test.go
@@ -9,65 +9,86 @@ import (
 func TestIgnoreAction_Match(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	data := []struct {
-		name       string
-		configName string
-		configRef  string
-		actionName string
-		actionRef  string
-		expected   bool
+		name         string
+		ignoreAction *run.IgnoreAction
+		actionName   string
+		actionRef    string
+		expected     bool
 	}{
 		{
-			name:       "match by name only",
-			configName: "actions/checkout",
-			configRef:  "",
+			name: "match by name only",
+			ignoreAction: &run.IgnoreAction{
+				Name:       "actions/checkout",
+				NameFormat: "fixed_string",
+			},
 			actionName: "actions/checkout",
 			actionRef:  "main",
 			expected:   true,
 		},
 		{
-			name:       "match by name and ref",
-			configName: "actions/checkout",
-			configRef:  "main",
+			name: "match by name and ref",
+			ignoreAction: &run.IgnoreAction{
+				Name:       "actions/checkout",
+				NameFormat: "fixed_string",
+				Ref:        "main",
+				RefFormat:  "fixed_string",
+			},
 			actionName: "actions/checkout",
 			actionRef:  "main",
 			expected:   true,
 		},
 		{
-			name:       "match by name but not by ref",
-			configName: "actions/checkout",
-			configRef:  "main",
+			name: "match by name but not by ref",
+			ignoreAction: &run.IgnoreAction{
+				Name:       "actions/checkout",
+				NameFormat: "fixed_string",
+				Ref:        "main",
+				RefFormat:  "fixed_string",
+			},
 			actionName: "actions/checkout",
 			actionRef:  "develop",
 			expected:   false,
 		},
 		{
-			name:       "match by regex name",
-			configName: "^actions/.*",
-			configRef:  "",
+			name: "match by regex name",
+			ignoreAction: &run.IgnoreAction{
+				Name:       "^actions/.*",
+				NameFormat: "regexp",
+			},
 			actionName: "actions/checkout",
 			actionRef:  "main",
 			expected:   true,
 		},
 		{
-			name:       "match by regex ref",
-			configName: "actions/checkout",
-			configRef:  "^v\\d+\\.\\d+\\.\\d+$",
+			name: "match by regex ref",
+			ignoreAction: &run.IgnoreAction{
+				Name:       "actions/checkout",
+				NameFormat: "fixed_string",
+				Ref:        "^v\\d+\\.\\d+\\.\\d+$",
+				RefFormat:  "regexp",
+			},
 			actionName: "actions/checkout",
 			actionRef:  "v3.5.2",
 			expected:   true,
 		},
 		{
-			name:       "match by regex ref but not match",
-			configName: "actions/checkout",
-			configRef:  "^v\\d+\\.\\d+\\.\\d+$",
+			name: "match by regex ref but not match",
+			ignoreAction: &run.IgnoreAction{
+				Name:       "actions/checkout",
+				NameFormat: "fixed_string",
+				Ref:        "^v\\d+\\.\\d+\\.\\d+$",
+				RefFormat:  "regexp",
+			},
 			actionName: "actions/checkout",
 			actionRef:  "main",
 			expected:   false,
 		},
 		{
-			name:       "not match by name",
-			configName: "actions/checkout",
-			configRef:  "",
+			name: "not match by name",
+			ignoreAction: &run.IgnoreAction{
+				Name:       "actions/checkout",
+				NameFormat: "fixed_string",
+			},
 			actionName: "actions/setup-go",
 			actionRef:  "main",
 			expected:   false,
@@ -77,12 +98,13 @@ func TestIgnoreAction_Match(t *testing.T) { //nolint:funlen
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
 			t.Parallel()
-			config, err := run.NewIgnoreAction(d.configName, d.configRef)
-			if err != nil {
-				t.Fatalf("failed to create ignore action: %v", err)
+			if err := d.ignoreAction.Init(); err != nil {
+				t.Fatalf("failed to initialize ignore action: %v", err)
 			}
-
-			got := config.Match(d.actionName, d.actionRef)
+			got, err := d.ignoreAction.Match(d.actionName, d.actionRef)
+			if err != nil {
+				t.Fatalf("failed to match: %v", err)
+			}
 			if got != d.expected {
 				t.Fatalf("wanted %v, got %v", d.expected, got)
 			}

--- a/pkg/controller/run/controller.go
+++ b/pkg/controller/run/controller.go
@@ -10,15 +10,11 @@ import (
 type Controller struct {
 	repositoriesService RepositoriesService
 	fs                  afero.Fs
-	update              bool
 	cfg                 *Config
+	param               *ParamRun
 }
 
-type InputNew struct {
-	Update bool
-}
-
-func New(ctx context.Context, input *InputNew) *Controller {
+func New(ctx context.Context, param *ParamRun) *Controller {
 	gh := github.New(ctx)
 	return &Controller{
 		repositoriesService: &RepositoriesServiceImpl{
@@ -27,8 +23,8 @@ func New(ctx context.Context, input *InputNew) *Controller {
 			commits:             map[string]*GetCommitSHA1Result{},
 			RepositoriesService: gh.Repositories,
 		},
-		fs:     afero.NewOsFs(),
-		update: input.Update,
+		param: param,
+		fs:    afero.NewOsFs(),
 	}
 }
 

--- a/pkg/controller/run/controller.go
+++ b/pkg/controller/run/controller.go
@@ -16,5 +16,6 @@ func New(repositoriesService RepositoriesService, fs afero.Fs, param *ParamRun) 
 		repositoriesService: repositoriesService,
 		param:               param,
 		fs:                  fs,
+		cfg:                 &Config{},
 	}
 }

--- a/pkg/controller/run/controller.go
+++ b/pkg/controller/run/controller.go
@@ -1,10 +1,7 @@
 package run
 
 import (
-	"context"
-
 	"github.com/spf13/afero"
-	"github.com/suzuki-shunsuke/pinact/pkg/github"
 )
 
 type Controller struct {
@@ -14,23 +11,10 @@ type Controller struct {
 	param               *ParamRun
 }
 
-func New(ctx context.Context, param *ParamRun) *Controller {
-	gh := github.New(ctx)
+func New(repositoriesService RepositoriesService, fs afero.Fs, param *ParamRun) *Controller {
 	return &Controller{
-		repositoriesService: &RepositoriesServiceImpl{
-			tags:                map[string]*ListTagsResult{},
-			releases:            map[string]*ListReleasesResult{},
-			commits:             map[string]*GetCommitSHA1Result{},
-			RepositoriesService: gh.Repositories,
-		},
-		param: param,
-		fs:    afero.NewOsFs(),
-	}
-}
-
-func NewController(repoService RepositoriesService, fs afero.Fs) *Controller {
-	return &Controller{
-		repositoriesService: repoService,
+		repositoriesService: repositoriesService,
+		param:               param,
 		fs:                  fs,
 	}
 }

--- a/pkg/controller/run/controller.go
+++ b/pkg/controller/run/controller.go
@@ -2,20 +2,33 @@ package run
 
 import (
 	"github.com/spf13/afero"
+	"github.com/suzuki-shunsuke/pinact/pkg/config"
 )
 
 type Controller struct {
 	repositoriesService RepositoriesService
 	fs                  afero.Fs
-	cfg                 *Config
+	cfg                 *config.Config
 	param               *ParamRun
+	cfgFinder           ConfigFinder
+	cfgReader           ConfigReader
 }
 
-func New(repositoriesService RepositoriesService, fs afero.Fs, param *ParamRun) *Controller {
+type ConfigFinder interface {
+	Find(configFilePath string) (string, error)
+}
+
+type ConfigReader interface {
+	Read(cfg *config.Config, configFilePath string) error
+}
+
+func New(repositoriesService RepositoriesService, fs afero.Fs, cfgFinder ConfigFinder, cfgReader ConfigReader, param *ParamRun) *Controller {
 	return &Controller{
 		repositoriesService: repositoriesService,
 		param:               param,
 		fs:                  fs,
-		cfg:                 &Config{},
+		cfgFinder:           cfgFinder,
+		cfgReader:           cfgReader,
+		cfg:                 &config.Config{},
 	}
 }

--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -18,12 +18,12 @@ type RepositoriesService interface {
 
 func (r *RepositoriesServiceImpl) GetCommitSHA1(ctx context.Context, owner, repo, ref, lastSHA string) (string, *github.Response, error) {
 	key := fmt.Sprintf("%s/%s/%s", owner, repo, ref)
-	a, ok := r.commits[key]
+	a, ok := r.Commits[key]
 	if ok {
 		return a.SHA, a.Response, a.err
 	}
 	sha, resp, err := r.RepositoriesService.GetCommitSHA1(ctx, owner, repo, ref, lastSHA)
-	r.commits[key] = &GetCommitSHA1Result{
+	r.Commits[key] = &GetCommitSHA1Result{
 		SHA:      sha,
 		Response: resp,
 		err:      err,
@@ -45,9 +45,9 @@ type ListReleasesResult struct {
 
 type RepositoriesServiceImpl struct {
 	RepositoriesService RepositoriesService
-	tags                map[string]*ListTagsResult
-	commits             map[string]*GetCommitSHA1Result
-	releases            map[string]*ListReleasesResult
+	Tags                map[string]*ListTagsResult
+	Commits             map[string]*GetCommitSHA1Result
+	Releases            map[string]*ListReleasesResult
 }
 
 type GetCommitSHA1Result struct {
@@ -58,12 +58,12 @@ type GetCommitSHA1Result struct {
 
 func (r *RepositoriesServiceImpl) ListTags(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error) {
 	key := fmt.Sprintf("%s/%s/%v", owner, repo, opts.Page)
-	a, ok := r.tags[key]
+	a, ok := r.Tags[key]
 	if ok {
 		return a.Tags, a.Response, a.err
 	}
 	tags, resp, err := r.RepositoriesService.ListTags(ctx, owner, repo, opts)
-	r.tags[key] = &ListTagsResult{
+	r.Tags[key] = &ListTagsResult{
 		Tags:     tags,
 		Response: resp,
 		err:      err,
@@ -73,12 +73,12 @@ func (r *RepositoriesServiceImpl) ListTags(ctx context.Context, owner string, re
 
 func (r *RepositoriesServiceImpl) ListReleases(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {
 	key := fmt.Sprintf("%s/%s/%v", owner, repo, opts.Page)
-	a, ok := r.releases[key]
+	a, ok := r.Releases[key]
 	if ok {
 		return a.Releases, a.Response, a.err
 	}
 	releases, resp, err := r.RepositoriesService.ListReleases(ctx, owner, repo, opts)
-	r.releases[key] = &ListReleasesResult{
+	r.Releases[key] = &ListReleasesResult{
 		Releases: releases,
 		Response: resp,
 		err:      err,

--- a/pkg/controller/run/init.go
+++ b/pkg/controller/run/init.go
@@ -10,28 +10,21 @@ import (
 const (
 	templateConfig = `# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
 # pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
 # files:
 #   - pattern: action.yaml
-#     pattern_format: fixed_string
 #   - pattern: */action.yaml
-#     pattern_format: glob
-#   - pattern: "^(.*/)?action\\.ya?ml$"
-#     pattern_format: regexp
 
 ignore_actions:
 # - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
 #   name_format: fixed_string
-# - name: actions/*
-#   name_format: glob
+# - name: ^actions/.*
+#   name_format: regexp
 #   ref: main
 #   ref_format: fixed_string
-# - name: actions/.*
+# - name: ^suzuki-shunsuke/.*
 #   name_format: regexp
-#   ref: release-*
-#   ref_format: glob
-# - name: suzuki-shunsuke/commit-action
-#   name_format: fixed_string
-#   ref: ^release-.*$
+#   ref: ^release-.*
 #   ref_format: regexp
 `
 	filePermission os.FileMode = 0o644

--- a/pkg/controller/run/init.go
+++ b/pkg/controller/run/init.go
@@ -10,13 +10,29 @@ import (
 const (
 	templateConfig = `# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
 # pinact - https://github.com/suzuki-shunsuke/pinact
-files:
-  - pattern: "^\\.github/workflows/.*\\.ya?ml$"
-  - pattern: "^(.*/)?action\\.ya?ml$"
+# files:
+#   - pattern: action.yaml
+#     pattern_format: fixed_string
+#   - pattern: */action.yaml
+#     pattern_format: glob
+#   - pattern: "^(.*/)?action\\.ya?ml$"
+#     pattern_format: regexp
 
 ignore_actions:
-# - name: actions/checkout
 # - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
+#   name_format: fixed_string
+# - name: actions/*
+#   name_format: glob
+#   ref: main
+#   ref_format: fixed_string
+# - name: actions/.*
+#   name_format: regexp
+#   ref: release-*
+#   ref_format: glob
+# - name: suzuki-shunsuke/commit-action
+#   name_format: fixed_string
+#   ref: ^release-.*$
+#   ref_format: regexp
 `
 	filePermission os.FileMode = 0o644
 )

--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -89,7 +89,12 @@ func (c *Controller) parseLine(ctx context.Context, logE *logrus.Entry, line str
 	logE = logE.WithField("action", action.Name+"@"+action.Version)
 
 	for _, ignoreAction := range c.cfg.IgnoreActions {
-		if ignoreAction.Match(action.Name, action.Version) {
+		f, err := ignoreAction.Match(action.Name, action.Version)
+		if err != nil {
+			logerr.WithError(logE, err).Warn("match the action")
+			continue
+		}
+		if f {
 			logE.Debug("ignore the action")
 			return "", nil
 		}
@@ -136,7 +141,7 @@ func (c *Controller) parseNoTagLine(ctx context.Context, logE *logrus.Entry, act
 		return "", ErrCantPinned
 	}
 	// @xxx
-	if c.update {
+	if c.param.Update {
 		// get the latest version
 		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
 		if err != nil {
@@ -172,7 +177,7 @@ func (c *Controller) parseNoTagLine(ctx context.Context, logE *logrus.Entry, act
 
 func (c *Controller) parseSemverTagLine(ctx context.Context, logE *logrus.Entry, action *Action) (string, error) {
 	// @xxx # v3.0.0
-	if c.update {
+	if c.param.Update {
 		// get the latest version
 		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
 		if err != nil {
@@ -207,7 +212,7 @@ func (c *Controller) parseShortSemverTagLine(ctx context.Context, logE *logrus.E
 	if FullCommitSHA != getVersionType(action.Version) {
 		return "", ErrCantPinned
 	}
-	if c.update {
+	if c.param.Update {
 		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)

--- a/pkg/controller/run/parse_line_internal_test.go
+++ b/pkg/controller/run/parse_line_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+	"github.com/suzuki-shunsuke/pinact/pkg/config"
 	"github.com/suzuki-shunsuke/pinact/pkg/github"
 	"github.com/suzuki-shunsuke/pinact/pkg/util"
 )
@@ -155,6 +156,7 @@ func TestController_parseLine(t *testing.T) { //nolint:funlen
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
 			t.Parallel()
+			fs := afero.NewMemMapFs()
 			ctrl := New(&RepositoriesServiceImpl{
 				Tags: map[string]*ListTagsResult{
 					"actions/checkout/0": {
@@ -195,8 +197,7 @@ func TestController_parseLine(t *testing.T) { //nolint:funlen
 						SHA: "ee0669bd1cc54295c223e0bb666b733df41de1c5",
 					},
 				},
-			}, afero.NewMemMapFs(), &ParamRun{})
-			ctrl.cfg = &Config{}
+			}, fs, config.NewFinder(fs), config.NewReader(fs), &ParamRun{})
 			line, err := ctrl.parseLine(ctx, logE, d.line)
 			if err != nil {
 				if d.isErr {

--- a/pkg/controller/run/parse_line_internal_test.go
+++ b/pkg/controller/run/parse_line_internal_test.go
@@ -155,8 +155,8 @@ func TestController_parseLine(t *testing.T) { //nolint:funlen
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
 			t.Parallel()
-			ctrl := NewController(&RepositoriesServiceImpl{
-				tags: map[string]*ListTagsResult{
+			ctrl := New(&RepositoriesServiceImpl{
+				Tags: map[string]*ListTagsResult{
 					"actions/checkout/0": {
 						Tags: []*github.RepositoryTag{
 							{
@@ -187,7 +187,7 @@ func TestController_parseLine(t *testing.T) { //nolint:funlen
 						Response: &github.Response{},
 					},
 				},
-				commits: map[string]*GetCommitSHA1Result{
+				Commits: map[string]*GetCommitSHA1Result{
 					"actions/checkout/v3": {
 						SHA: "8e5e7e5ab8b370d6c329ec480221332ada57f0ab",
 					},
@@ -195,7 +195,7 @@ func TestController_parseLine(t *testing.T) { //nolint:funlen
 						SHA: "ee0669bd1cc54295c223e0bb666b733df41de1c5",
 					},
 				},
-			}, afero.NewMemMapFs())
+			}, afero.NewMemMapFs(), &ParamRun{})
 			ctrl.cfg = &Config{}
 			line, err := ctrl.parseLine(ctx, logE, d.line)
 			if err != nil {

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -25,7 +25,7 @@ func (c *Controller) Run(ctx context.Context, logE *logrus.Entry) error {
 	if err := c.readConfig(); err != nil {
 		return err
 	}
-	workflowFilePaths, err := c.searchFiles(logE)
+	workflowFilePaths, err := c.searchFiles()
 	if err != nil {
 		return fmt.Errorf("search target files: %w", err)
 	}

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -26,7 +26,7 @@ func (c *Controller) Run(ctx context.Context, logE *logrus.Entry) error {
 	if err := c.readConfig(); err != nil {
 		return err
 	}
-	workflowFilePaths, err := c.searchFiles()
+	workflowFilePaths, err := c.searchFiles(logE)
 	if err != nil {
 		return fmt.Errorf("search target files: %w", err)
 	}

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
+	"github.com/suzuki-shunsuke/pinact/pkg/config"
 )
 
 type ParamRun struct {
@@ -51,6 +52,20 @@ func (c *Controller) Run(ctx context.Context, logE *logrus.Entry) error {
 	if failed {
 		return ErrNotPinned
 	}
+	return nil
+}
+
+func (c *Controller) readConfig() error {
+	p, err := c.cfgFinder.Find(c.param.ConfigFilePath)
+	if err != nil {
+		return fmt.Errorf("find a configurationfile: %w", err)
+	}
+	c.param.ConfigFilePath = p
+	cfg := &config.Config{}
+	if err := c.cfgReader.Read(cfg, c.param.ConfigFilePath); err != nil {
+		return fmt.Errorf("read a config file: %w", err)
+	}
+	c.cfg = cfg
 	return nil
 }
 

--- a/pkg/controller/run/search_file.go
+++ b/pkg/controller/run/search_file.go
@@ -2,20 +2,36 @@ package run
 
 import (
 	"fmt"
+	"io/fs"
 	"path/filepath"
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 )
 
-func (c *Controller) searchFiles() ([]string, error) {
+func (c *Controller) searchFiles(logE *logrus.Entry) ([]string, error) {
 	if len(c.param.WorkflowFilePaths) != 0 {
 		return c.param.WorkflowFilePaths, nil
 	}
 	if c.cfg != nil && len(c.cfg.Files) > 0 {
-		return c.searchFilesByConfig()
+		return c.searchFilesByConfig(logE)
 	}
 	return listWorkflows()
 }
 
-func (c *Controller) searchFilesByConfig() ([]string, error) {
+func (c *Controller) searchFilesByConfig(logE *logrus.Entry) ([]string, error) {
+	switch c.cfg.Version {
+	case 0, 2:
+		return c.searchFilesByRegexp(logE)
+	case 3:
+		return c.searchFilesByGlob()
+	default:
+		return nil, fmt.Errorf("unsupported version %d", c.cfg.Version)
+	}
+}
+
+func (c *Controller) searchFilesByGlob() ([]string, error) {
 	files := []string{}
 	configFileDir := filepath.Dir(c.param.ConfigFilePath)
 	for _, file := range c.cfg.Files {
@@ -25,5 +41,52 @@ func (c *Controller) searchFilesByConfig() ([]string, error) {
 		}
 		files = append(files, matches...)
 	}
+	return files, nil
+}
+
+func (c *Controller) searchFilesByRegexp(logE *logrus.Entry) ([]string, error) {
+	patterns := make([]*regexp.Regexp, 0, len(c.cfg.Files))
+	configFileDir := filepath.Dir(c.param.ConfigFilePath)
+	for _, file := range c.cfg.Files {
+		if file.Pattern == "" {
+			// ignore
+			continue
+		}
+		p, err := regexp.Compile(file.Pattern)
+		if err != nil {
+			return nil, fmt.Errorf("parse files[].pattern as a regular expression: %w", err)
+		}
+		patterns = append(patterns, p)
+	}
+
+	files := []string{}
+	if err := fs.WalkDir(afero.NewIOFS(c.fs), configFileDir, func(p string, dirEntry fs.DirEntry, e error) error {
+		if e != nil {
+			return nil //nolint:nilerr
+		}
+		if dirEntry.IsDir() {
+			// ignore directory
+			return nil
+		}
+		filePath, err := filepath.Rel(configFileDir, p)
+		if err != nil {
+			logE.WithFields(logrus.Fields{
+				"config_file_dir": configFileDir,
+				"path":            p,
+			}).WithError(err).Debug("get a relative path")
+			return nil
+		}
+		sp := filepath.ToSlash(filePath)
+		for _, pattern := range patterns {
+			if pattern.MatchString(sp) {
+				files = append(files, filePath)
+				break
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("search target files: %w", err)
+	}
+
 	return files, nil
 }

--- a/pkg/controller/run/search_file.go
+++ b/pkg/controller/run/search_file.go
@@ -22,9 +22,9 @@ func (c *Controller) searchFiles(logE *logrus.Entry) ([]string, error) {
 
 func (c *Controller) searchFilesByConfig(logE *logrus.Entry) ([]string, error) {
 	switch c.cfg.Version {
-	case 0, 2:
+	case 0, 2: //nolint:mnd
 		return c.searchFilesByRegexp(logE)
-	case 3:
+	case 3: //nolint:mnd
 		return c.searchFilesByGlob()
 	default:
 		return nil, fmt.Errorf("unsupported version %d", c.cfg.Version)

--- a/pkg/controller/run/search_file.go
+++ b/pkg/controller/run/search_file.go
@@ -9,7 +9,7 @@ func (c *Controller) searchFiles() ([]string, error) {
 	if len(c.param.WorkflowFilePaths) != 0 {
 		return c.param.WorkflowFilePaths, nil
 	}
-	if len(c.cfg.Files) > 0 {
+	if c.cfg != nil && len(c.cfg.Files) > 0 {
 		return c.searchFilesByConfig()
 	}
 	return listWorkflows()

--- a/pkg/controller/run/search_file.go
+++ b/pkg/controller/run/search_file.go
@@ -2,68 +2,27 @@ package run
 
 import (
 	"fmt"
-	"io/fs"
 	"path/filepath"
-
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 )
 
-func (c *Controller) searchFiles(logE *logrus.Entry) ([]string, error) {
+func (c *Controller) searchFiles() ([]string, error) {
 	if len(c.param.WorkflowFilePaths) != 0 {
 		return c.param.WorkflowFilePaths, nil
 	}
 	if len(c.cfg.Files) > 0 {
-		return c.searchFilesByConfig(logE)
+		return c.searchFilesByConfig()
 	}
 	return listWorkflows()
 }
 
-func (c *Controller) searchFilesByConfig(logE *logrus.Entry) ([]string, error) {
+func (c *Controller) searchFilesByConfig() ([]string, error) {
 	files := []string{}
 	for _, file := range c.cfg.Files {
-		switch file.PatternFormat {
-		case "fixed_string":
-			files = append(files, file.Pattern)
-			continue
-		case "glob":
-			matches, err := filepath.Glob(file.Pattern)
-			if err != nil {
-				return nil, fmt.Errorf("search target files: %w", err)
-			}
-			files = append(files, matches...)
-		case "regexp":
-			if err := fs.WalkDir(afero.NewIOFS(c.fs), c.param.PWD, func(p string, dirEntry fs.DirEntry, e error) error {
-				if e != nil {
-					return nil //nolint:nilerr
-				}
-				if dirEntry.IsDir() {
-					// ignore directory
-					return nil
-				}
-				filePath, err := filepath.Rel(c.param.PWD, p)
-				if err != nil {
-					logE.WithFields(logrus.Fields{
-						"pwd":  c.param.PWD,
-						"path": p,
-					}).WithError(err).Debug("get a relative path")
-					return nil
-				}
-				sp := filepath.ToSlash(filePath)
-				for _, file := range c.cfg.Files {
-					if file.patternRegexp.MatchString(sp) {
-						files = append(files, filePath)
-						break
-					}
-				}
-				return nil
-			}); err != nil {
-				return nil, fmt.Errorf("search target files: %w", err)
-			}
-		default:
-			return nil, fmt.Errorf("unexpected pattern format: %s", file.PatternFormat)
+		matches, err := filepath.Glob(file.Pattern)
+		if err != nil {
+			return nil, fmt.Errorf("search target files: %w", err)
 		}
+		files = append(files, matches...)
 	}
-
 	return files, nil
 }

--- a/pkg/controller/run/search_file.go
+++ b/pkg/controller/run/search_file.go
@@ -17,8 +17,9 @@ func (c *Controller) searchFiles() ([]string, error) {
 
 func (c *Controller) searchFilesByConfig() ([]string, error) {
 	files := []string{}
+	configFileDir := filepath.Dir(c.param.ConfigFilePath)
 	for _, file := range c.cfg.Files {
-		matches, err := filepath.Glob(file.Pattern)
+		matches, err := filepath.Glob(filepath.Join(configFileDir, file.Pattern))
 		if err != nil {
 			return nil, fmt.Errorf("search target files: %w", err)
 		}


### PR DESCRIPTION
Close #846

The following configuration fields are added:

- `ignore_actions[].name_format`
- `ignore_actions[].ref_format`

Available values of these fields are:

- `fixed_string`
- `glob`
- `regexp`

## ⚠️ Breaking Changes

- The format of `files[].pattern` is changed from a regular expression to a glob
- A required config `ignore_actions[].name_format` is added
- `ignore_actions[].ref_format` is required if `ignore_actions[].ref` is set