### PR TITLE
feat: loosen restrictions around semantic tags

### DIFF
--- a/pkg/controller/run/parse_line_internal_test.go
+++ b/pkg/controller/run/parse_line_internal_test.go
@@ -135,6 +135,16 @@ func TestController_parseLine(t *testing.T) { //nolint:funlen
 			exp:  "  uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0",
 		},
 		{
+			name: "mixed v1",
+			line: "  uses: mixed-tags/foo-action@v1",
+			exp:  "  uses: mixed-tags/foo-action@f3128156ad18877fd068ebe75b2dca3ff85077b4 # v1.2.3",
+		},
+		{
+			name: "mixed v2",
+			line: "  uses: mixed-tags/foo-action@v2",
+			exp:  "  uses: mixed-tags/foo-action@a02c5346fcf0693696326351d206d7b1f5c6126d # v2",
+		},
+		{
 			name: "single quote",
 			line: `  - "uses": 'actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab' # v3`,
 			exp:  `  - "uses": 'actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab' # v3.5.2`,
@@ -186,6 +196,29 @@ func TestController_parseLine(t *testing.T) { //nolint:funlen
 						},
 						Response: &github.Response{},
 					},
+					"mixed-tags/foo-action/0": {
+						Tags: []*github.RepositoryTag{
+							{
+								Name: util.StrP("v1"),
+								Commit: &github.Commit{
+									SHA: util.StrP("f3128156ad18877fd068ebe75b2dca3ff85077b4"),
+								},
+							},
+							{
+								Name: util.StrP("v1.2.3"),
+								Commit: &github.Commit{
+									SHA: util.StrP("f3128156ad18877fd068ebe75b2dca3ff85077b4"),
+								},
+							},
+							{
+								Name: util.StrP("v2"),
+								Commit: &github.Commit{
+									SHA: util.StrP("a02c5346fcf0693696326351d206d7b1f5c6126d"),
+								},
+							},
+						},
+						Response: &github.Response{},
+					},
 				},
 				Commits: map[string]*GetCommitSHA1Result{
 					"actions/checkout/v3": {
@@ -193,6 +226,12 @@ func TestController_parseLine(t *testing.T) { //nolint:funlen
 					},
 					"actions/checkout/v2": {
 						SHA: "ee0669bd1cc54295c223e0bb666b733df41de1c5",
+					},
+					"mixed-tags/foo-action/v1": {
+						SHA: "f3128156ad18877fd068ebe75b2dca3ff85077b4",
+					},
+					"mixed-tags/foo-action/v2": {
+						SHA: "a02c5346fcf0693696326351d206d7b1f5c6126d",
 					},
 				},
 			}, fs, config.NewFinder(fs), config.NewReader(fs), &ParamRun{})

--- a/testdata/foo.yaml
+++ b/testdata/foo.yaml
@@ -19,6 +19,8 @@ jobs:
       - 'uses': "actions/checkout@v3"
       - "uses": 'actions/checkout@v3'
       - uses: cardinalby/git-get-release-action@cf4593dd18e51a1ecfbfb1c68abac9910a8b1e0c # v1
+      - uses: DeterminateSystems/nix-installer-action@v17
+      - uses: DeterminateSystems/nix-installer-action@21a544727d0c62386e78b4befe52d19ad12692e3 # v17
   actionlint:
     uses: suzuki-shunsuke/actionlint-workflow/.github/workflows/actionlint.yaml@v0.5.0
     with:

--- a/testdata/foo.yaml.after
+++ b/testdata/foo.yaml.after
@@ -19,6 +19,8 @@ jobs:
       - 'uses': "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744" # v3.6.0
       - "uses": 'actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744' # v3.6.0
       - uses: cardinalby/git-get-release-action@cf4593dd18e51a1ecfbfb1c68abac9910a8b1e0c # v1
+      - uses: DeterminateSystems/nix-installer-action@21a544727d0c62386e78b4befe52d19ad12692e3 # v17
+      - uses: DeterminateSystems/nix-installer-action@21a544727d0c62386e78b4befe52d19ad12692e3 # v17
   actionlint:
     uses: suzuki-shunsuke/actionlint-workflow/.github/workflows/actionlint.yaml@b6a5f966d4504893b2aeb60cf2b0de8946e48504 # v0.5.0
     with:


### PR DESCRIPTION
This change combines the "semantic" and "non-semantic" tag workflows into a single one which supports a wider range of "version tag" specifications (that is, tags that match the regex `^v?\d+(\.\d+){0,2}[^ ]*$`). A key behavior change that this introduces is support for action repositories which do not use a fully qualified semantic version for release tags, such as "v5", with no alternate like "v5.x.y".

The behavior of `parseTagLine` imitates the previous workflow, such that we attempt to replace "non-semantic" version tags (but ultimately just select the tag that matches the sha, regardless of its semantic validity). Because these are "version strings" (like "v1" or "v1.2.3"), the semantic conversion performed for comparison still works -- "v1" would be seen as `1.0.0`, and when compared against `1.2.3`, the latter would win. This results in a biased selection process which prefers 3-octect version strings over those that are not, without rejecting them.

Closes: #939
Change-Id: Ibb13c4216a0682355a7d38880e607b6cb7d7ff03