### PR TITLE
feat: Add pre-commit hooks to validate workflow and action files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,24 @@
+---
+- id: pinact
+  name: Validate versions of Actions and reusable workflows
+  description: Validate versions of GitHub Actions and reusable workflows
+  entry: pinact run --check
+  language: golang
+  types: [yaml]
+  files: ^(\.github/workflows/[^/]+|([^/]+/){0,3}action)\.ya?ml$
+
+- id: pinact-fix
+  name: Pin versions of Actions and reusable workflows
+  description: Pin versions of GitHub Actions and reusable workflows
+  entry: pinact run
+  language: golang
+  types: [yaml]
+  files: ^(\.github/workflows/[^/]+|([^/]+/){0,3}action)\.ya?ml$
+
+- id: pinact-update
+  name: Pin and update versions of Actions and reusable workflows
+  description: Pin and update versions of GitHub Actions and reusable workflows
+  entry: pinact run --update
+  language: golang
+  types: [yaml]
+  files: ^(\.github/workflows/[^/]+|([^/]+/){0,3}action)\.ya?ml$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,7 +10,8 @@
 - id: pinact-fix
   name: Pin versions of Actions and reusable workflows
   description: Pin versions of GitHub Actions and reusable workflows
-  entry: pinact run
+  entry: pinact run --fix
+  args: [--diff]
   language: golang
   types: [yaml]
   files: ^(\.github/workflows/[^/]+|([^/]+/){0,3}action)\.ya?ml$
@@ -19,6 +20,7 @@
   name: Pin and update versions of Actions and reusable workflows
   description: Pin and update versions of GitHub Actions and reusable workflows
   entry: pinact run --update
+  args: [--diff]
   language: golang
   types: [yaml]
   files: ^(\.github/workflows/[^/]+|([^/]+/){0,3}action)\.ya?ml$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -24,3 +24,11 @@
   language: golang
   types: [yaml]
   files: ^(\.github/workflows/[^/]+|([^/]+/){0,3}action)\.ya?ml$
+
+- id: pinact-system
+  name: Pin versions of Actions and reusable workflows
+  description: Pin versions of GitHub Actions and reusable workflows
+  entry: pinact run
+  language: system
+  types: [yaml]
+  files: ^(\.github/workflows/[^/]+|([^/]+/){0,3}action)\.ya?ml$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,17 +1,8 @@
 ---
 - id: pinact
-  name: Validate versions of Actions and reusable workflows
-  description: Validate versions of GitHub Actions and reusable workflows
-  entry: pinact run --check
-  language: golang
-  types: [yaml]
-  files: ^(\.github/workflows/[^/]+|([^/]+/){0,3}action)\.ya?ml$
-
-- id: pinact-fix
   name: Pin versions of Actions and reusable workflows
   description: Pin versions of GitHub Actions and reusable workflows
-  entry: pinact run --fix
-  args: [--diff]
+  entry: pinact run --verify-comment
   language: golang
   types: [yaml]
   files: ^(\.github/workflows/[^/]+|([^/]+/){0,3}action)\.ya?ml$
@@ -19,8 +10,15 @@
 - id: pinact-update
   name: Pin and update versions of Actions and reusable workflows
   description: Pin and update versions of GitHub Actions and reusable workflows
-  entry: pinact run --update
-  args: [--diff]
+  entry: pinact run --verify-comment --update
+  language: golang
+  types: [yaml]
+  files: ^(\.github/workflows/[^/]+|([^/]+/){0,3}action)\.ya?ml$
+
+- id: pinact-check
+  name: Validate versions of Actions and reusable workflows
+  description: Validate versions of GitHub Actions and reusable workflows
+  entry: pinact run --verify-comment --check
   language: golang
   types: [yaml]
   files: ^(\.github/workflows/[^/]+|([^/]+/){0,3}action)\.ya?ml$
@@ -28,7 +26,7 @@
 - id: pinact-system
   name: Pin versions of Actions and reusable workflows
   description: Pin versions of GitHub Actions and reusable workflows
-  entry: pinact run
+  entry: pinact run --verify-comment
   language: system
   types: [yaml]
   files: ^(\.github/workflows/[^/]+|([^/]+/){0,3}action)\.ya?ml$


### PR DESCRIPTION
Users can run pinact before committing or on CI.

- `pinact`: Validate versions of Actions and reusable workflows (This will not make any changes)
- `pinact-fix`: Pin versions of Actions and reusable workflows
- `pinact-update`: Pin and update versions of Actions and reusable workflows
- `pinact-system`: Validate versions of Actions and reusable workflows using locally installed `pinact` (This will not make any changes)

```yaml
# .pre-commit-config.yaml
repos:
  - repo: https://github.com/suzuki-shunsuke/pinact
    rev: <tag/branch>
    hooks:
      - id: pinact
```

resolve #930

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/suzuki-shunsuke/pinact/issues/930
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

<!-- Please write the description here -->
