### PR TITLE
feat: support creating reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ If pinact is run via GitHub Actions `pull_request` event, options are auto-compl
 > [!WARNING]
 > GitHub can't create pull request reviews on files not changed by the pull request.
 > When pinact fails to create reviews, pinact outputs warning and creates [GitHub Actions error messages to log instead](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message).
+> You can ignore the warning like this:
+> ```
+> WARN[0004] create a review comment                       error="create a review comment: POST https://api.github.com/repos/szksh-lab-2/test-github-action/pulls/317/comments: 422 Validation Failed [{Resource:PullRequestReviewComment Field:pull_request_review_thread.path Code:invalid Message:} {Resource:PullRequestReviewComment Field:pull_request_review_thread.diff_hunk Code:missing_field Message:}]" line="      - uses: suzuki-shunsuke/watch-star-action@feat/first-pr" line_number=14 pinact_version=3.3.0-5 program=pinact review_pr_number=317 review_repo_name=test-github-action review_repo_owner=szksh-lab-2 review_sha=92f0b04efdc10acb793e78bdd1f70958dd3fd9a3 workflow_file=.github/workflows/watch.yaml
+> ```
 
 ![error-message-log](https://github.com/user-attachments/assets/0231dee4-4473-459b-8ea4-e4c6a1f417c8)
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ pinact run \
 
 If pinact is run via GitHub Actions `pull_request` event, options are auto-completed.
 
+> [!WARNING]
+> GitHub can't create pull request reviews on files not changed by the pull request.
+> When pinact fails to create reviews, pinact outputs warning and creates [GitHub Actions error messages to log instead](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message).
+
+![error-message-log](https://github.com/user-attachments/assets/0231dee4-4473-459b-8ea4-e4c6a1f417c8)
+
 ### Generate a configuration file `.pinact.yaml`
 
 A configuration file is optional.

--- a/README.md
+++ b/README.md
@@ -229,11 +229,17 @@ $ echo $?
 1
 ```
 
-If `-check` is set, files aren't fixed.
+If `-check` is set, files aren't fixed and no diff is outputted.
 If you want to fix files, please use `-fix` option.
 
 ```sh
 pinact run -check -fix
+```
+
+And if you want to output diff, please use `-diff` option.
+
+```sh
+pinact run -check -diff
 ```
 
 ### Verify version annotations
@@ -262,9 +268,8 @@ No option | o | | |
 -check | | o | |
 -diff | | | o
 -check -diff | | o | o
--check -fix | o | o |
+-check -fix | o | o | o
 -fix -diff | o | | o
--check -diff -fix | o | o | o
 
 ## GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Motivation](#motivation) | [Install](INSTALL.md) | [How to use](#how-to-use) | [GitHub Actions](https://github.com/suzuki-shunsuke/pinact-action) | [Configuration](#configuration) | [Contributing](CONTRIBUTING.md) | [LICENSE](LICENSE)
 
 pinact is a CLI to edit GitHub Workflow and Composite action files and pin versions of Actions and Reusable Workflows.
-pinact can also [update their versions](#update-actions) and [verify version annotations](docs/codes/001.md).
+pinact can also [update their versions](#update-actions), [verify version annotations](docs/codes/001.md), and [create reviews]().
 
 ```sh
 pinact run
@@ -38,6 +38,10 @@ index 84bd67a..5d92e44 100644
        aqua_version: v2.3.4
      permissions:
 ```
+
+Creating reviews:
+
+![review](https://github.com/user-attachments/assets/77e78d23-bd14-49ba-8097-751556fcf126)
 
 ## Motivation
 
@@ -164,6 +168,24 @@ pinact can fix example codes in documents too.
 pinact run README.md
 ```
 
+### Create reviews
+
+![review](https://github.com/user-attachments/assets/77e78d23-bd14-49ba-8097-751556fcf126)
+
+As of pinact v3.3.0, pinact can create reviews by GitHub API.
+A GitHub access token with `pull_requests:write` permission is required.
+
+```sh
+pinact run \
+  -review \
+  -repo-owner <repository owner> \
+  -repo-name <repository name> \
+  -pr <pull request number> \
+  -sha <commit SHA to be reviewed>
+```
+
+If pinact is run via GitHub Actions `pull_request` event, options are auto-completed.
+
 ### Generate a configuration file `.pinact.yaml`
 
 A configuration file is optional.
@@ -207,9 +229,42 @@ $ echo $?
 1
 ```
 
+If `-check` is set, files aren't fixed.
+If you want to fix files, please use `-fix` option.
+
+```sh
+pinact run -check -fix
+```
+
 ### Verify version annotations
 
 Please see [the document](docs/codes/001.md).
+
+### Output diff
+
+```console
+$ pinact run -diff
+INFO[0000] action isn't pinned
+.github/workflows/test.yaml:8
+-       - uses: actions/checkout@v4
++       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  pinact_version=v3.0.0-local program=pinact
+```
+
+### -diff, -check, -fix options
+
+The behaviour of `pinact run` command is changed by command line options `-diff`, `-check`, and `-fix`.
+This is a table how the behaviour is changed by these options.
+
+options | Fix files | Exit with code 1 if actions aren't pinned | Output changes
+--- | --- | --- | ---
+No option | o | | |
+-check | | o | |
+-diff | | | o
+-check -diff | | o | o
+-check -fix | o | o |
+-fix -diff | o | | o
+-check -diff -fix | o | o | o
 
 ## GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Motivation](#motivation) | [Install](INSTALL.md) | [How to use](#how-to-use) | [GitHub Actions](https://github.com/suzuki-shunsuke/pinact-action) | [Configuration](#configuration) | [Contributing](CONTRIBUTING.md) | [LICENSE](LICENSE)
 
 pinact is a CLI to edit GitHub Workflow and Composite action files and pin versions of Actions and Reusable Workflows.
-pinact can also [update their versions](#update-actions), [verify version annotations](docs/codes/001.md), and [create reviews]().
+pinact can also [update their versions](#update-actions), [verify version annotations](docs/codes/001.md), and [create reviews](#create-reviews).
 
 ```sh
 pinact run

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/suzuki-shunsuke/pinact/v3
 go 1.24.2
 
 require (
+	github.com/fatih/color v1.18.0
 	github.com/goccy/go-yaml v1.18.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v72 v72.0.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=

--- a/pkg/cli/initcmd/command.go
+++ b/pkg/cli/initcmd/command.go
@@ -53,7 +53,7 @@ func (r *runner) action(ctx context.Context, c *cli.Command) error {
 		Releases:            map[string]*run.ListReleasesResult{},
 		Commits:             map[string]*run.GetCommitSHA1Result{},
 		RepositoriesService: gh.Repositories,
-	}, afero.NewOsFs(), nil, nil, &run.ParamRun{
+	}, gh.PullRequests, afero.NewOsFs(), nil, nil, &run.ParamRun{
 		WorkflowFilePaths: c.Args().Slice(),
 		ConfigFilePath:    c.String("config"),
 		PWD:               pwd,

--- a/pkg/cli/run/command.go
+++ b/pkg/cli/run/command.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
@@ -157,6 +158,10 @@ func (r *runner) action(ctx context.Context, c *cli.Command) error {
 	}
 
 	isGitHubActions := os.Getenv("GITHUB_ACTIONS") == "true"
+	if isGitHubActions {
+		log.SetColor("always", r.logE)
+		color.NoColor = false
+	}
 
 	gh := github.New(ctx, r.logE)
 	fs := afero.NewOsFs()

--- a/pkg/cli/run/command.go
+++ b/pkg/cli/run/command.go
@@ -63,7 +63,7 @@ $ pinact run .github/actions/foo/action.yaml .github/actions/bar/action.yaml
 			},
 			&cli.BoolFlag{
 				Name:  "fix",
-				Usage: "Fix code. By default, this is true. If -check is true, this is false by default",
+				Usage: "Fix code. By default, this is true. If -check or -diff is true, this is false by default",
 			},
 			&cli.BoolFlag{
 				Name:  "diff",
@@ -192,7 +192,7 @@ func (r *runner) action(ctx context.Context, c *cli.Command) error {
 	}
 	if c.IsSet("fix") {
 		param.Fix = c.Bool("fix")
-	} else if c.Bool("check") {
+	} else if param.Check || param.Diff {
 		param.Fix = false
 	}
 	ctrl := run.New(&run.RepositoriesServiceImpl{

--- a/pkg/cli/run/command.go
+++ b/pkg/cli/run/command.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -206,7 +207,15 @@ func (r *runner) action(ctx context.Context, c *cli.Command) error {
 
 func (r *runner) setReview(fs afero.Fs, review *run.Review) error {
 	if review.RepoName == "" {
-		review.RepoName = os.Getenv("GITHUB_REPOSITORY_OWNER")
+		repo := os.Getenv("GITHUB_REPOSITORY")
+		_, repoName, ok := strings.Cut(repo, "/")
+		if !ok {
+			return fmt.Errorf("GITHUB_REPOSITORY is not set or invalid: %s", repo)
+		}
+		if repoName == "" {
+			return fmt.Errorf("GITHUB_REPOSITORY is invalid: %s", repo)
+		}
+		review.RepoName = repoName
 	}
 	eventPath := os.Getenv("GITHUB_EVENT_PATH")
 	if eventPath == "" {

--- a/pkg/cli/run/command.go
+++ b/pkg/cli/run/command.go
@@ -62,10 +62,6 @@ $ pinact run .github/actions/foo/action.yaml .github/actions/bar/action.yaml
 				Usage: "Create reviews",
 			},
 			&cli.BoolFlag{
-				Name:  "fail",
-				Usage: "Fail if any action is not pinned",
-			},
-			&cli.BoolFlag{
 				Name:  "fix",
 				Usage: "Fix code. By default, this is true. If -check is true, this is false by default",
 			},
@@ -188,7 +184,6 @@ func (r *runner) action(ctx context.Context, c *cli.Command) error {
 		IsVerify:          c.Bool("verify"),
 		Check:             c.Bool("check"),
 		Update:            c.Bool("update"),
-		Fail:              c.Bool("fail"),
 		Diff:              c.Bool("diff"),
 		Fix:               true,
 		IsGitHubActions:   isGitHubActions,

--- a/pkg/cli/run/command.go
+++ b/pkg/cli/run/command.go
@@ -237,8 +237,8 @@ func (r *runner) setReview(fs afero.Fs, review *run.Review) error {
 		if err := r.readEvent(fs, ev, eventPath); err != nil {
 			return err
 		}
-		review.SHA = ev.SHA()
 	}
+	review.SHA = ev.SHA()
 	return nil
 }
 

--- a/pkg/cli/run/command.go
+++ b/pkg/cli/run/command.go
@@ -61,6 +61,10 @@ $ pinact run .github/actions/foo/action.yaml .github/actions/bar/action.yaml
 				Name:  "review",
 				Usage: "Create reviews",
 			},
+			&cli.BoolFlag{
+				Name:  "fail",
+				Usage: "Fail if any action is not pinned",
+			},
 			&cli.StringFlag{
 				Name:    "repo-owner",
 				Usage:   "GitHub repository owner",
@@ -181,6 +185,7 @@ func (r *runner) action(ctx context.Context, c *cli.Command) error {
 		IsVerify:          c.Bool("verify"),
 		Check:             c.Bool("check"),
 		Update:            c.Bool("update"),
+		Fail:              c.Bool("fail"),
 		IsGitHubActions:   isGitHubActions,
 		Stderr:            os.Stderr,
 		Review:            review,

--- a/pkg/cli/run/command.go
+++ b/pkg/cli/run/command.go
@@ -2,11 +2,13 @@ package run
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+	"github.com/suzuki-shunsuke/logrus-error/logerr"
 	"github.com/suzuki-shunsuke/pinact/v3/pkg/config"
 	"github.com/suzuki-shunsuke/pinact/v3/pkg/controller/run"
 	"github.com/suzuki-shunsuke/pinact/v3/pkg/github"
@@ -55,8 +57,87 @@ $ pinact run .github/actions/foo/action.yaml .github/actions/bar/action.yaml
 				Aliases: []string{"u"},
 				Usage:   "Update actions to latest versions",
 			},
+			&cli.BoolFlag{
+				Name:  "review",
+				Usage: "Create reviews",
+			},
+			&cli.StringFlag{
+				Name:    "repo-owner",
+				Usage:   "GitHub repository owner",
+				Sources: cli.EnvVars("GITHUB_REPOSITORY_OWNER"),
+			},
+			&cli.StringFlag{
+				Name:  "repo-name",
+				Usage: "GitHub repository name",
+			},
+			&cli.StringFlag{
+				Name:  "sha",
+				Usage: "Commit SHA to be reviewed",
+			},
+			&cli.IntFlag{
+				Name:  "pr",
+				Usage: "GitHub pull request number",
+			},
 		},
 	}
+}
+
+type Event struct {
+	PullRequest *PullRequest `json:"pull_request"`
+	Issue       *Issue       `json:"issue"`
+	Repository  *Repository  `json:"repository"`
+}
+
+func (e *Event) RepoName() string {
+	if e != nil && e.Repository != nil {
+		return e.Repository.Name
+	}
+	return ""
+}
+
+func (e *Event) PRNumber() int {
+	if e == nil {
+		return 0
+	}
+	if e.PullRequest != nil {
+		return e.PullRequest.Number
+	}
+	if e.Issue != nil {
+		return e.Issue.Number
+	}
+	return 0
+}
+
+func (e *Event) SHA() string {
+	if e == nil {
+		return ""
+	}
+	if e.PullRequest != nil && e.PullRequest.Head != nil {
+		return e.PullRequest.Head.SHA
+	}
+	return ""
+}
+
+type Issue struct {
+	Number int `json:"number"`
+}
+
+type PullRequest struct {
+	Number int   `json:"number"`
+	Head   *Head `json:"head"`
+}
+
+type Repository struct {
+	Owner *Owner `json:"owner"`
+	Name  string `json:"name"`
+}
+
+type Owner struct {
+	Login string `json:"login"`
+}
+
+type Head struct {
+	SHA string `json:"sha"`
 }
 
 func (r *runner) action(ctx context.Context, c *cli.Command) error {
@@ -66,22 +147,81 @@ func (r *runner) action(ctx context.Context, c *cli.Command) error {
 		return fmt.Errorf("get the current directory: %w", err)
 	}
 
+	isGitHubActions := os.Getenv("GITHUB_ACTIONS") == "true"
+
 	gh := github.New(ctx, r.logE)
 	fs := afero.NewOsFs()
+	var review *run.Review
+	if c.Bool("review") {
+		review = &run.Review{
+			RepoOwner:   c.String("repo-owner"),
+			RepoName:    c.String("repo-name"),
+			PullRequest: c.Int("pr"),
+			SHA:         c.String("sha"),
+		}
+		if isGitHubActions {
+			if err := r.setReview(fs, review); err != nil {
+				logerr.WithError(r.logE, err).Error("set review information")
+			}
+		}
+		if !review.Valid() {
+			r.logE.Warn("skip creating reviews because the review information is invalid")
+			review = nil
+		}
+	}
 	ctrl := run.New(&run.RepositoriesServiceImpl{
 		Tags:                map[string]*run.ListTagsResult{},
 		Releases:            map[string]*run.ListReleasesResult{},
 		Commits:             map[string]*run.GetCommitSHA1Result{},
 		RepositoriesService: gh.Repositories,
-	}, fs, config.NewFinder(fs), config.NewReader(fs), &run.ParamRun{
+	}, gh.PullRequests, fs, config.NewFinder(fs), config.NewReader(fs), &run.ParamRun{
 		WorkflowFilePaths: c.Args().Slice(),
 		ConfigFilePath:    c.String("config"),
 		PWD:               pwd,
 		IsVerify:          c.Bool("verify"),
 		Check:             c.Bool("check"),
 		Update:            c.Bool("update"),
-		IsGitHubActions:   os.Getenv("GITHUB_ACTIONS") == "true",
+		IsGitHubActions:   isGitHubActions,
 		Stderr:            os.Stderr,
+		Review:            review,
 	})
 	return ctrl.Run(ctx, r.logE) //nolint:wrapcheck
+}
+
+func (r *runner) setReview(fs afero.Fs, review *run.Review) error {
+	if review.RepoName == "" {
+		review.RepoName = os.Getenv("GITHUB_REPOSITORY_OWNER")
+	}
+	eventPath := os.Getenv("GITHUB_EVENT_PATH")
+	if eventPath == "" {
+		return nil
+	}
+	var ev *Event
+	if review.PullRequest == 0 {
+		if err := r.readEvent(fs, ev, eventPath); err != nil {
+			return err
+		}
+		review.PullRequest = ev.PRNumber()
+	}
+	if review.SHA != "" {
+		return nil
+	}
+	if ev == nil {
+		if err := r.readEvent(fs, ev, eventPath); err != nil {
+			return err
+		}
+		review.SHA = ev.SHA()
+	}
+	return nil
+}
+
+func (r *runner) readEvent(fs afero.Fs, ev *Event, eventPath string) error {
+	event, err := fs.Open(eventPath)
+	if err != nil {
+		return fmt.Errorf("read GITHUB_EVENT_PATH: %w", err)
+	}
+	if err := json.NewDecoder(event).Decode(&ev); err != nil {
+		return fmt.Errorf("unmarshal GITHUB_EVENT_PATH: %w", err)
+	}
+	return nil
 }

--- a/pkg/controller/run/controller.go
+++ b/pkg/controller/run/controller.go
@@ -7,6 +7,7 @@ import (
 
 type Controller struct {
 	repositoriesService RepositoriesService
+	pullRequestsService PullRequestsService
 	fs                  afero.Fs
 	cfg                 *config.Config
 	param               *ParamRun
@@ -22,9 +23,10 @@ type ConfigReader interface {
 	Read(cfg *config.Config, configFilePath string) error
 }
 
-func New(repositoriesService RepositoriesService, fs afero.Fs, cfgFinder ConfigFinder, cfgReader ConfigReader, param *ParamRun) *Controller {
+func New(repositoriesService RepositoriesService, pullRequestsService PullRequestsService, fs afero.Fs, cfgFinder ConfigFinder, cfgReader ConfigReader, param *ParamRun) *Controller {
 	return &Controller{
 		repositoriesService: repositoriesService,
+		pullRequestsService: pullRequestsService,
 		param:               param,
 		fs:                  fs,
 		cfgFinder:           cfgFinder,

--- a/pkg/controller/run/controller.go
+++ b/pkg/controller/run/controller.go
@@ -13,6 +13,7 @@ type Controller struct {
 	param               *ParamRun
 	cfgFinder           ConfigFinder
 	cfgReader           ConfigReader
+	logger              *Logger
 }
 
 type ConfigFinder interface {
@@ -32,5 +33,6 @@ func New(repositoriesService RepositoriesService, pullRequestsService PullReques
 		cfgFinder:           cfgFinder,
 		cfgReader:           cfgReader,
 		cfg:                 &config.Config{},
+		logger:              NewLogger(param.Stderr),
 	}
 }

--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/go-version"
@@ -182,9 +183,10 @@ func (c *Controller) review(ctx context.Context, filePath string, sha string, li
 	const header = "Reviewed by [pinact](https://github.com/suzuki-shunsuke/pinact)"
 	if suggestion != "" {
 		cmt.Body = github.Ptr(fmt.Sprintf("%s\n```suggestion\n%s\n```", header, suggestion))
-	}
-	if err != nil {
+	} else if err != nil {
 		cmt.Body = github.Ptr(fmt.Sprintf("%s\n%s", header, err.Error()))
+	} else {
+		return errors.New("Either suggestion or error must be provided")
 	}
 	_, _, e := c.pullRequestsService.CreateComment(ctx, c.param.Review.RepoOwner, c.param.Review.RepoName, c.param.Review.PullRequest, cmt)
 	if e != nil {

--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -186,7 +186,7 @@ func (c *Controller) review(ctx context.Context, filePath string, sha string, li
 	} else if err != nil {
 		cmt.Body = github.Ptr(fmt.Sprintf("%s\n%s", header, err.Error()))
 	} else {
-		return errors.New("Either suggestion or error must be provided")
+		return errors.New("either suggestion or error must be provided")
 	}
 	_, _, e := c.pullRequestsService.CreateComment(ctx, c.param.Review.RepoOwner, c.param.Review.RepoName, c.param.Review.PullRequest, cmt)
 	if e != nil {

--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -181,11 +181,12 @@ func (c *Controller) review(ctx context.Context, filePath string, sha string, li
 		cmt.CommitID = github.Ptr(sha)
 	}
 	const header = "Reviewed by [pinact](https://github.com/suzuki-shunsuke/pinact)"
-	if suggestion != "" {
+	switch {
+	case suggestion != "":
 		cmt.Body = github.Ptr(fmt.Sprintf("%s\n```suggestion\n%s\n```", header, suggestion))
-	} else if err != nil {
+	case err != nil:
 		cmt.Body = github.Ptr(fmt.Sprintf("%s\n%s", header, err.Error()))
-	} else {
+	default:
 		return errors.New("either suggestion or error must be provided")
 	}
 	_, _, e := c.pullRequestsService.CreateComment(ctx, c.param.Review.RepoOwner, c.param.Review.RepoName, c.param.Review.PullRequest, cmt)

--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -179,7 +179,7 @@ func (c *Controller) review(ctx context.Context, filePath string, sha string, li
 	if sha != "" {
 		cmt.CommitID = github.Ptr(sha)
 	}
-	const header = "<sub>reported by [pinact](https://github.com/suzuki-shunsuke/pinact)</sub>"
+	const header = "Reviewed by [pinact](https://github.com/suzuki-shunsuke/pinact)"
 	if suggestion != "" {
 		cmt.Body = github.Ptr(fmt.Sprintf("%s\n```suggestion\n%s\n```", header, suggestion))
 	}
@@ -187,5 +187,8 @@ func (c *Controller) review(ctx context.Context, filePath string, sha string, li
 		cmt.Body = github.Ptr(fmt.Sprintf("%s\n%s", header, err.Error()))
 	}
 	_, _, e := c.pullRequestsService.CreateComment(ctx, c.param.Review.RepoOwner, c.param.Review.RepoName, c.param.Review.PullRequest, cmt)
-	return fmt.Errorf("create a review comment: %w", e)
+	if e != nil {
+		return fmt.Errorf("create a review comment: %w", e)
+	}
+	return nil
 }

--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -101,7 +101,7 @@ func (c *Controller) parseLine(ctx context.Context, logE *logrus.Entry, line str
 		}
 	}
 
-	if c.param.Check && !c.param.Diff {
+	if c.param.Check && !c.param.Diff && !c.param.Fix {
 		if fullCommitSHAPattern.MatchString(action.Version) {
 			return "", nil
 		}

--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -83,7 +83,7 @@ func (c *Controller) parseLine(ctx context.Context, logE *logrus.Entry, line str
 	action := parseAction(line)
 	if action == nil {
 		// Ignore a line if the line doesn't use an action.
-		logE.WithField("line", line).Debug("unmatch")
+		logE.Debug("unmatch")
 		return "", nil
 	}
 
@@ -109,7 +109,7 @@ func (c *Controller) parseLine(ctx context.Context, logE *logrus.Entry, line str
 	}
 
 	if f := c.parseActionName(action); !f {
-		logE.WithField("line", line).Debug("ignore line")
+		logE.Debug("ignore line")
 		return "", nil
 	}
 

--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -101,7 +101,7 @@ func (c *Controller) parseLine(ctx context.Context, logE *logrus.Entry, line str
 		}
 	}
 
-	if c.param.Check {
+	if c.param.Check && !c.param.Diff {
 		if fullCommitSHAPattern.MatchString(action.Version) {
 			return "", nil
 		}

--- a/pkg/controller/run/parse_line_internal_test.go
+++ b/pkg/controller/run/parse_line_internal_test.go
@@ -195,7 +195,7 @@ func TestController_parseLine(t *testing.T) { //nolint:funlen
 						SHA: "ee0669bd1cc54295c223e0bb666b733df41de1c5",
 					},
 				},
-			}, fs, config.NewFinder(fs), config.NewReader(fs), &ParamRun{})
+			}, nil, fs, config.NewFinder(fs), config.NewReader(fs), &ParamRun{})
 			line, err := ctrl.parseLine(t.Context(), logE, d.line)
 			if err != nil {
 				if d.isErr {

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -229,7 +229,7 @@ func (c *Controller) handleChangedLine(ctx context.Context, logE *logrus.Entry, 
 		if c.param.Check {
 			level = levelError
 		}
-		fmt.Fprintf(c.param.Stderr, "::%s file=%s,line=%d,title=action isn't pinned::\n", level, line.File, line.Number)
+		fmt.Fprintf(c.param.Stderr, "::%s file=%s,line=%d,title=pinact error::action isn't pinned\n", level, line.File, line.Number)
 	}
 	// Output diff
 	if !c.param.Check && c.param.Fix && !c.param.Diff {

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -35,6 +35,15 @@ type Review struct {
 	SHA         string
 }
 
+func (r *Review) Fields() logrus.Fields {
+	return logrus.Fields{
+		"review_repo_owner": r.RepoOwner,
+		"review_repo_name":  r.RepoName,
+		"review_pr_number":  r.PullRequest,
+		"review_sha":        r.SHA,
+	}
+}
+
 func (r *Review) Valid() bool {
 	return r != nil && r.RepoOwner != "" && r.RepoName != "" && r.PullRequest > 0
 }
@@ -183,7 +192,7 @@ func (c *Controller) handleParseLineError(ctx context.Context, logE *logrus.Entr
 	}
 	// Create review
 	if err := c.review(ctx, line.File, c.param.Review.SHA, line.Number, "", gErr); err != nil {
-		logerr.WithError(logE, err).Error("create a review comment")
+		logerr.WithError(logE, err).WithFields(c.param.Review.Fields()).Error("create a review comment")
 		// Output GitHub Actions error
 		if c.param.IsGitHubActions {
 			fmt.Fprintf(c.param.Stderr, "::error file=%s,line=%d,title=pinact error::%s\n", line.File, line.Number, gErr)
@@ -196,7 +205,7 @@ func (c *Controller) handleChangedLine(ctx context.Context, logE *logrus.Entry, 
 	if c.param.Review != nil {
 		// Create review
 		if err := c.review(ctx, line.File, c.param.Review.SHA, line.Number, newLine, nil); err != nil {
-			logerr.WithError(logE, err).Error("create a review comment")
+			logerr.WithError(logE, err).WithFields(c.param.Review.Fields()).Error("create a review comment")
 		} else {
 			reviewed = true
 		}

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -23,6 +23,8 @@ type ParamRun struct {
 	Check             bool
 	IsGitHubActions   bool
 	Fail              bool
+	Fix               bool
+	Diff              bool
 	Stderr            io.Writer
 	Review            *Review
 }

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -163,6 +163,9 @@ func (c *Controller) runWorkflow(ctx context.Context, logE *logrus.Entry, workfl
 		}
 		return nil
 	}
+	if !c.param.Fix {
+		return nil
+	}
 	f, err := os.Create(workflowFilePath)
 	if err != nil {
 		return fmt.Errorf("create a workflow file: %w", err)

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -206,15 +206,11 @@ func (c *Controller) handleParseLineError(ctx context.Context, logE *logrus.Entr
 	}
 	// Create review
 	if code, err := c.review(ctx, line.File, c.param.Review.SHA, line.Number, "", gErr); err != nil {
+		level := logrus.ErrorLevel
 		if code == http.StatusUnprocessableEntity {
-			logerr.WithError(logE, err).WithFields(c.param.Review.Fields()).Warn("create a review comment")
-			// Output GitHub Actions error
-			if c.param.IsGitHubActions {
-				fmt.Fprintf(c.param.Stderr, "::notice file=%s,line=%d,title=pinact error::%s\n", line.File, line.Number, gErr)
-			}
-			return
+			level = logrus.WarnLevel
 		}
-		logerr.WithError(logE, err).WithFields(c.param.Review.Fields()).Error("create a review comment")
+		logerr.WithError(logE, err).WithFields(c.param.Review.Fields()).Log(level, "create a review comment")
 		// Output GitHub Actions error
 		if c.param.IsGitHubActions {
 			fmt.Fprintf(c.param.Stderr, "::error file=%s,line=%d,title=pinact error::%s\n", line.File, line.Number, gErr)

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -11,18 +11,23 @@ import (
 )
 
 type (
-	ListOptions       = github.ListOptions
-	Reference         = github.Reference
-	Response          = github.Response
-	RepositoryTag     = github.RepositoryTag
-	RepositoryRelease = github.RepositoryRelease
-	Client            = github.Client
-	GitObject         = github.GitObject
-	Commit            = github.Commit
+	ListOptions        = github.ListOptions
+	Reference          = github.Reference
+	Response           = github.Response
+	RepositoryTag      = github.RepositoryTag
+	RepositoryRelease  = github.RepositoryRelease
+	Client             = github.Client
+	GitObject          = github.GitObject
+	Commit             = github.Commit
+	PullRequestComment = github.PullRequestComment
 )
 
 func New(ctx context.Context, logE *logrus.Entry) *Client {
 	return github.NewClient(getHTTPClientForGitHub(ctx, logE, getGitHubToken()))
+}
+
+func Ptr[T any](v T) *T {
+	return github.Ptr(v)
 }
 
 func getGitHubToken() string {


### PR DESCRIPTION
Close #1006

## Features

- Support creating pull request reviews
- Support outputting diff
- Support fixing code while using `-check` option

### Support creating pull request reviews

![review](https://github.com/user-attachments/assets/77e78d23-bd14-49ba-8097-751556fcf126)

This pull request enables pinact to create reviews by GitHub API.
A GitHub access token with `pull_requests:write` permission is required.

```sh
pinact run \
  -review \
  -repo-owner <repository owner> \
  -repo-name <repository name> \
  -pr <pull request number> \
  -sha <commit SHA to be reviewed>
```

If pinact is run via GitHub Actions `pull_request` event, options are auto-completed.

> [!WARNING]
> GitHub can't create pull request reviews on files not changed by the pull request.
> When pinact fails to create reviews, pinact outputs warning and creates [GitHub Actions error messages to log instead](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message).
> You can ignore the warning like this:
> ```
> WARN[0004] create a review comment                       error="create a review comment: POST https://api.github.com/repos/szksh-lab-2/test-github-action/pulls/317/comments: 422 Validation Failed [{Resource:PullRequestReviewComment Field:pull_request_review_thread.path Code:invalid Message:} {Resource:PullRequestReviewComment Field:pull_request_review_thread.diff_hunk Code:missing_field Message:}]" line="      - uses: suzuki-shunsuke/watch-star-action@feat/first-pr" line_number=14 pinact_version=3.3.0-5 program=pinact review_pr_number=317 review_repo_name=test-github-action review_repo_owner=szksh-lab-2 review_sha=92f0b04efdc10acb793e78bdd1f70958dd3fd9a3 workflow_file=.github/workflows/watch.yaml
> ```

![error-message-log](https://github.com/user-attachments/assets/0231dee4-4473-459b-8ea4-e4c6a1f417c8)

### Support outputting diff

Using `-diff` option, pinact can output diff.

```sh
pinact run -diff
```

```
ERROR action isn't pinned
.github/workflows/test.yaml:14
-       - uses: aquaproj/aqua-installer@v4.0.0
+       - uses: aquaproj/aqua-installer@9ebf656952a20c45a5d66606f083ff34f58b8ce0 # v4.0.0
```

<img width="658" alt="image" src="https://github.com/user-attachments/assets/b279b920-e24f-4330-a46e-1a1247951e3f" />

### Fix code by `-fix` option

If `-check` or `-diff` option is set, pinact doesn't fix code by default.
By setting `-fix` option, you can fix code.

```sh
pinact run -check -fix
```

```sh
pinact run -diff -fix
```

### 📝  -diff, -check, -fix options

The behaviour of `pinact run` command is changed by command line options `-diff`, `-check`, and `-fix`.
This is a table how the behaviour is changed by these options.

options | Fix files | Exit with code 1 if actions aren't pinned | Output changes
--- | --- | --- | ---
No option | o | | |
-check | | o | |
-diff | | | o
-check -diff | | o | o
-check -fix | o | o | o
-fix -diff | o | | o
