### PR TITLE
fix(casks): restrict quarantine removal to macOS only

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ homebrew_casks:
     hooks:
       post:
         install: |
-          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+          if OS.mac?
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/pinact"]
           end
 


### PR DESCRIPTION
I was responsible for part of GoReleaser's Homebrew Cask support, but I overlooked an error in the sample code for removing quarantine bits on macOS, which was causing unexpected issues on Linux.
This PR fixes the cask definition so that quarantine bit removal only executes on macOS.

If this fix is acceptable, I plan to submit similar patches to other OSS projects that you release with GoReleaser.

Note: The erroneous sample code has already been fixed.
https://goreleaser.com/customization/homebrew_casks/?h=cask#signing-and-notarizing

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Since there's no issue with pinact itself, I'm skipping issue creation. Apologies if this approach is inappropriate.
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

<!-- Please write the description here -->
