### PR TITLE
fix(github): ignore prerelease versions when current version is stable

### DIFF
--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -166,6 +166,11 @@ func compare(latestSemver *version.Version, latestVersion, tag string) (*version
 		return latestSemver, latestVersion, fmt.Errorf("parse a tag as a semver: %w", err)
 	}
 	if latestSemver != nil {
+		// If current version is stable (not a prerelease) and new version is a prerelease,
+		// skip the prerelease version (issue #1095)
+		if latestSemver.Prerelease() == "" && v.Prerelease() != "" {
+			return latestSemver, "", nil
+		}
 		if v.GreaterThan(latestSemver) {
 			return v, "", nil
 		}

--- a/pkg/controller/run/github_internal_test.go
+++ b/pkg/controller/run/github_internal_test.go
@@ -120,6 +120,33 @@ func Test_compare(t *testing.T) { //nolint:funlen
 			wantLatestVersion: "",
 			wantErr:           false,
 		},
+		{
+			name:              "stable version should not update to prerelease (issue #1095)",
+			latestSemver:      version.Must(version.NewVersion("5.0.0")),
+			latestVersion:     "",
+			tag:               "v6-beta",
+			wantSemver:        "5.0.0",
+			wantLatestVersion: "",
+			wantErr:           false,
+		},
+		{
+			name:              "stable version should not update to prerelease with proper semver",
+			latestSemver:      version.Must(version.NewVersion("v5.0.0")),
+			latestVersion:     "",
+			tag:               "v6.0.0-beta",
+			wantSemver:        "v5.0.0",
+			wantLatestVersion: "",
+			wantErr:           false,
+		},
+		{
+			name:              "prerelease version can update to newer prerelease",
+			latestSemver:      version.Must(version.NewVersion("v6.0.0-beta")),
+			latestVersion:     "",
+			tag:               "v6.0.0-rc.1",
+			wantSemver:        "v6.0.0-rc.1",
+			wantLatestVersion: "",
+			wantErr:           false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Stable versions (e.g., v5.0.0) should not update to newer prerelease versions (e.g., v6-beta) when using `pinact run -u`. This fix adds a check in the compare function to skip prerelease candidates when the current version is stable.

Behavior:
- Stable versions only update to stable versions
- Prerelease versions can update to newer prereleases or stable versions

Fixes #1095

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: #1095
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

Note that this is a very simple take to just avoid issues like https://github.com/suzuki-shunsuke/pinact/issues/1095#issuecomment-3484102496

I'm happy to abandon this in favor of https://github.com/suzuki-shunsuke/pinact/pull/1096 
