### PR TITLE
fix(github): skip prereleases when current version is stable

### DIFF
--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -239,7 +239,7 @@ func (c *Controller) parseNoTagLine(ctx context.Context, logE *logrus.Entry, act
 	// @xxx
 	if c.param.Update {
 		// get the latest version
-		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
+		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName, "")
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)
 		}
@@ -306,7 +306,7 @@ func (c *Controller) parseSemverTagLine(ctx context.Context, logE *logrus.Entry,
 	// @xxx # v3.0.0
 	if c.param.Update { //nolint:nestif
 		// get the latest version
-		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
+		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName, action.VersionComment)
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)
 		}
@@ -360,7 +360,7 @@ func (c *Controller) parseShortSemverTagLine(ctx context.Context, logE *logrus.E
 		return "", ErrCantPinned
 	}
 	if c.param.Update {
-		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName)
+		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName, "")
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)
 		}


### PR DESCRIPTION
When updating GitHub Actions with `pinact run -u`, stable versions (e.g., v5.0.0) should not be updated to prerelease versions (e.g., v6-beta).

This fix:
- Adds currentVersion parameter to getLatestVersion() and getLatestVersionFromReleases()
- Checks if current version is stable via semver parsing
- Uses GitHub's Prerelease flag to filter releases when current is stable
- Allows prerelease-to-prerelease updates (e.g., v6-alpha to v6-beta)

The key insight is that some prereleases like "v6-beta" are invalid semver and fail to parse, so we must use GitHub's Prerelease metadata flag rather than relying solely on semver parsing.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:  #1095

- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

## How to run this yourself

Since the go.mod declares the module as github.com/suzuki-shunsuke/pinact/v3, you need to install from a local clone:

```sh
  # Clone and checkout the branch
  git clone https://github.com/mceachen/pinact.git /tmp/pinact-test-1095
  cd /tmp/pinact-test-1095
  git checkout fix-1095-simpler-try-2

  # Build and install
  cd cmd/pinact
  go install
```

This will install the pinact binary to ~/go/bin/pinact (or $GOPATH/bin/pinact).


