### PR TITLE
fix: fix currentVersion

### DIFF
--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -239,7 +239,7 @@ func (c *Controller) parseNoTagLine(ctx context.Context, logE *logrus.Entry, act
 	// @xxx
 	if c.param.Update {
 		// get the latest version
-		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName, "")
+		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName, action.Version)
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)
 		}
@@ -360,7 +360,7 @@ func (c *Controller) parseShortSemverTagLine(ctx context.Context, logE *logrus.E
 		return "", ErrCantPinned
 	}
 	if c.param.Update {
-		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName, "")
+		lv, err := c.getLatestVersion(ctx, logE, action.RepoOwner, action.RepoName, action.VersionComment)
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)
 		}


### PR DESCRIPTION
Fixed bugs of #1201 .

- #1201

## Test data

```yaml
- uses: actions/checkout@v4.0.0
- uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
```

## Test command

```sh
pinact run -u
```

## Before

These changes are undesirable.

```yaml
- uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
- uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
```

## After

```yaml
- uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
- uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
```