### PR TITLE
fix: prevent stable versions from updating to prereleases

### DIFF
--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -137,15 +137,24 @@ func (r *RepositoriesServiceImpl) ListReleases(ctx context.Context, owner string
 //   - currentVersion: current version to check if stable (empty string to include all versions)
 //
 // Returns the latest version string or an error.
-func (c *Controller) getLatestVersion(ctx context.Context, logE *logrus.Entry, owner string, repo string, currentVersion string) (string, error) {
-	lv, err := c.getLatestVersionFromReleases(ctx, logE, owner, repo, currentVersion)
+func (c *Controller) getLatestVersion(ctx context.Context, logE *logrus.Entry, owner, repo, currentVersion string) (string, error) {
+	isStable := isStableVersion(currentVersion)
+	lv, err := c.getLatestVersionFromReleases(ctx, logE, owner, repo, isStable)
 	if err != nil {
 		logerr.WithError(logE, err).Debug("get the latest version from releases")
 	}
 	if lv != "" {
 		return lv, nil
 	}
-	return c.getLatestVersionFromTags(ctx, logE, owner, repo, currentVersion)
+	return c.getLatestVersionFromTags(ctx, logE, owner, repo, isStable)
+}
+
+func isStableVersion(v string) bool {
+	if v == "" {
+		return false
+	}
+	cv, err := version.NewVersion(v)
+	return err == nil && cv.Prerelease() == ""
 }
 
 // compare evaluates a tag against the current latest version.
@@ -187,7 +196,7 @@ func compare(latestSemver *version.Version, latestVersion, tag string) (*version
 //   - currentVersion: current version to check if stable (empty string to include all versions)
 //
 // Returns the latest version string or an error.
-func (c *Controller) getLatestVersionFromReleases(ctx context.Context, logE *logrus.Entry, owner string, repo string, currentVersion string) (string, error) {
+func (c *Controller) getLatestVersionFromReleases(ctx context.Context, logE *logrus.Entry, owner, repo string, isStable bool) (string, error) {
 	opts := &github.ListOptions{
 		PerPage: 30, //nolint:mnd
 	}
@@ -196,20 +205,11 @@ func (c *Controller) getLatestVersionFromReleases(ctx context.Context, logE *log
 		return "", fmt.Errorf("list releases: %w", err)
 	}
 
-	// Check if current version is stable (issue #1095)
-	currentIsStable := false
-	if currentVersion != "" {
-		cv, err := version.NewVersion(currentVersion)
-		if err == nil && cv.Prerelease() == "" {
-			currentIsStable = true
-		}
-	}
-
 	var latestSemver *version.Version
 	latestVersion := ""
 	for _, release := range releases {
 		// Skip prereleases if current version is stable (issue #1095)
-		if currentIsStable && release.GetPrerelease() {
+		if isStable && release.GetPrerelease() {
 			continue
 		}
 		tag := release.GetTagName()
@@ -241,7 +241,7 @@ func (c *Controller) getLatestVersionFromReleases(ctx context.Context, logE *log
 //   - currentVersion: current version to check if stable (empty string to include all versions)
 //
 // Returns the latest version string or an error.
-func (c *Controller) getLatestVersionFromTags(ctx context.Context, logE *logrus.Entry, owner string, repo string, currentVersion string) (string, error) {
+func (c *Controller) getLatestVersionFromTags(ctx context.Context, logE *logrus.Entry, owner, repo string, isStable bool) (string, error) {
 	opts := &github.ListOptions{
 		PerPage: 30, //nolint:mnd
 	}
@@ -250,22 +250,13 @@ func (c *Controller) getLatestVersionFromTags(ctx context.Context, logE *logrus.
 		return "", fmt.Errorf("list tags: %w", err)
 	}
 
-	// Check if current version is stable (issue #1095)
-	currentIsStable := false
-	if currentVersion != "" {
-		cv, err := version.NewVersion(currentVersion)
-		if err == nil && cv.Prerelease() == "" {
-			currentIsStable = true
-		}
-	}
-
 	var latestSemver *version.Version
 	latestVersion := ""
 	for _, tag := range tags {
 		t := tag.GetName()
 
 		// Skip prereleases if current version is stable (issue #1095)
-		if currentIsStable {
+		if isStable {
 			if tv, err := version.NewVersion(t); err == nil && tv.Prerelease() != "" {
 				continue
 			}
@@ -298,7 +289,7 @@ func (c *Controller) getLatestVersionFromTags(ctx context.Context, logE *logrus.
 //   - err: error to report (mutually exclusive with suggestion)
 //
 // Returns the HTTP status code and any error.
-func (c *Controller) review(ctx context.Context, filePath string, sha string, line int, suggestion string, err error) (int, error) {
+func (c *Controller) review(ctx context.Context, filePath, sha string, line int, suggestion string, err error) (int, error) {
 	cmt := &github.PullRequestComment{
 		Body: github.Ptr(""),
 		Path: github.Ptr(filePath),

--- a/pkg/controller/run/github_internal_test.go
+++ b/pkg/controller/run/github_internal_test.go
@@ -180,12 +180,12 @@ func (m *mockRepositoriesService) ListReleases(ctx context.Context, owner, repo 
 func TestController_getLatestVersionFromReleases(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	tests := []struct {
-		name           string
-		releases       []*github.RepositoryRelease
-		listErr        error
-		currentVersion string
-		wantVersion    string
-		wantErr        bool
+		name        string
+		releases    []*github.RepositoryRelease
+		listErr     error
+		isStable    bool
+		wantVersion string
+		wantErr     bool
 	}{
 		{
 			name: "single semver release",
@@ -290,9 +290,9 @@ func TestController_getLatestVersionFromReleases(t *testing.T) { //nolint:funlen
 				{TagName: github.Ptr("v5.0.0"), Prerelease: github.Ptr(false)},
 				{TagName: github.Ptr("v4.3.0"), Prerelease: github.Ptr(false)},
 			},
-			currentVersion: "v5.0.0",
-			wantVersion:    "v5.0.0",
-			wantErr:        false,
+			isStable:    true,
+			wantVersion: "v5.0.0",
+			wantErr:     false,
 		},
 		{
 			name: "prerelease version can update to newer prerelease (issue #1095)",
@@ -300,9 +300,9 @@ func TestController_getLatestVersionFromReleases(t *testing.T) { //nolint:funlen
 				{TagName: github.Ptr("v6-beta"), Prerelease: github.Ptr(true)},
 				{TagName: github.Ptr("v5.0.0"), Prerelease: github.Ptr(false)},
 			},
-			currentVersion: "v6-alpha",
-			wantVersion:    "v6-beta",
-			wantErr:        false,
+			isStable:    false,
+			wantVersion: "v6-beta",
+			wantErr:     false,
 		},
 	}
 
@@ -322,7 +322,7 @@ func TestController_getLatestVersionFromReleases(t *testing.T) { //nolint:funlen
 			ctx := t.Context()
 			logE := logrus.NewEntry(logrus.New())
 
-			gotVersion, err := c.getLatestVersionFromReleases(ctx, logE, "owner", "repo", tt.currentVersion)
+			gotVersion, err := c.getLatestVersionFromReleases(ctx, logE, "owner", "repo", tt.isStable)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getLatestVersionFromReleases() error = %v, wantErr %v", err, tt.wantErr)
@@ -479,7 +479,7 @@ func TestController_getLatestVersionFromTags(t *testing.T) { //nolint:funlen
 			ctx := t.Context()
 			logE := logrus.NewEntry(logrus.New())
 
-			gotVersion, err := c.getLatestVersionFromTags(ctx, logE, "owner", "repo", "")
+			gotVersion, err := c.getLatestVersionFromTags(ctx, logE, "owner", "repo", false)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getLatestVersionFromTags() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/controller/run/parse_line_internal_test.go
+++ b/pkg/controller/run/parse_line_internal_test.go
@@ -14,10 +14,6 @@ func strP(s string) *string {
 	return &s
 }
 
-func boolP(b bool) *bool {
-	return &b
-}
-
 func Test_parseAction(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	data := []struct {


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

<!-- Please write the description here -->

When getLatestVersionFromReleases returns empty and code falls back to getLatestVersionFromTags, prereleases were not being filtered out for stable current versions. This caused stable versions like v4 to incorrectly update to prereleases like v6-beta instead of the latest stable version.

Added currentVersion parameter to getLatestVersionFromTags and implemented the same prerelease filtering logic as getLatestVersionFromReleases to ensure consistent behavior regardless of which code path is taken.

Fixes #1216
