### PR TITLE
fix(docs): update Go install command to use version v3

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,7 +46,7 @@ aqua g -i suzuki-shunsuke/pinact
 ## Build an executable binary from source code yourself using Go
 
 ```sh
-go install github.com/suzuki-shunsuke/pinact/cmd/pinact@latest
+go install github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@latest
 ```
 
 ## GitHub Releases


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
- [x] (so trivial that I don't think it was warranted): [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

<!-- Please write the description here -->

The `go install` command in INSTALL.md was using the v1 module path, which installs the outdated v1.6.0 instead of the current v3.x release.

- Old: `go install github.com/suzuki-shunsuke/pinact/cmd/pinact@latest` → installs v1.6.0
- New: `go install github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@latest` → installs v3.5.0+

## Test plan

Verified with `go list -m -versions`:
- `github.com/suzuki-shunsuke/pinact` only has versions up to v1.6.0
- `github.com/suzuki-shunsuke/pinact/v3` has the current v3.x releases
