### PR TITLE
feat: add PINACT_GITHUB_TOKEN_FOR_REVIEW and PINACT_GHES_TOKEN_FOR_REVIEW

### DIFF
--- a/pkg/di/env.go
+++ b/pkg/di/env.go
@@ -2,8 +2,10 @@ package di
 
 // Secrets holds sensitive tokens for GitHub API authentication.
 type Secrets struct {
-	GitHubToken string
-	GHESToken   string
+	GitHubToken          string
+	GHESToken            string
+	GitHubTokenForReview string
+	GHESTokenForReview   string
 }
 
 // SetFromEnv sets secrets from environment variables.
@@ -12,6 +14,8 @@ func (s *Secrets) SetFromEnv(getEnv func(string) string) {
 	if s.GitHubToken == "" {
 		s.GitHubToken = getEnv("GITHUB_TOKEN")
 	}
+	s.GitHubTokenForReview = getEnv("PINACT_GITHUB_TOKEN_FOR_REVIEW")
+	s.GHESTokenForReview = getEnv("PINACT_GHES_TOKEN_FOR_REVIEW")
 	for _, envName := range []string{"PINACT_GHES_TOKEN", "GHES_TOKEN", "GITHUB_TOKEN_ENTERPRISE", "GITHUB_ENTERPRISE_TOKEN"} {
 		if token := getEnv(envName); token != "" {
 			s.GHESToken = token

--- a/pkg/di/run.go
+++ b/pkg/di/run.go
@@ -49,7 +49,7 @@ func Run(ctx context.Context, logger *slogutil.Logger, flags *Flags, secrets *Se
 	if err != nil {
 		return err
 	}
-	services, err := setupGHESServices(ctx, gh, cfg, flags, secrets.GHESToken)
+	services, err := setupGHESServices(ctx, gh, cfg, flags, secrets.GHESToken, secrets.GitHubTokenForReview, secrets.GHESTokenForReview)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When these environment variables are set and -review flag is used, the review tokens are used for creating PR review comments. This allows using separate tokens with pull_requests:write scope for reviews. If the tokens are not set, the default tokens are used as before.

- PINACT_GITHUB_TOKEN_FOR_REVIEW: for github.com reviews
- PINACT_GHES_TOKEN_FOR_REVIEW: for GHES reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)