### PR TITLE
feat(sarif): add fixes field for reviewdog suggestion support

### DIFF
--- a/pkg/controller/run/sarif.go
+++ b/pkg/controller/run/sarif.go
@@ -70,7 +70,7 @@ func (c *Controller) buildSARIFResults() []sarif.Result {
 			}
 		}
 
-		results = append(results, sarif.Result{
+		result := sarif.Result{
 			RuleID:  ruleID,
 			Level:   level,
 			Message: sarif.Message{Text: msg},
@@ -86,7 +86,34 @@ func (c *Controller) buildSARIFResults() []sarif.Result {
 					},
 				},
 			},
-		})
+		}
+
+		// Add fix suggestion if NewLine is available
+		if f.NewLine != "" {
+			result.Fixes = []sarif.Fix{
+				{
+					ArtifactChanges: []sarif.ArtifactChange{
+						{
+							ArtifactLocation: sarif.ArtifactLocation{
+								URI: f.File,
+							},
+							Replacements: []sarif.Replacement{
+								{
+									DeletedRegion: sarif.Region{
+										StartLine: f.Line,
+									},
+									InsertedContent: &sarif.ArtifactContent{
+										Text: f.NewLine,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+		}
+
+		results = append(results, result)
 	}
 	return results
 }

--- a/pkg/sarif/sarif.go
+++ b/pkg/sarif/sarif.go
@@ -39,6 +39,29 @@ type Result struct {
 	Level     string     `json:"level"`
 	Message   Message    `json:"message"`
 	Locations []Location `json:"locations"`
+	Fixes     []Fix      `json:"fixes,omitempty"`
+}
+
+// Fix represents a proposed fix for a result.
+type Fix struct {
+	ArtifactChanges []ArtifactChange `json:"artifactChanges"`
+}
+
+// ArtifactChange represents a change to a single artifact.
+type ArtifactChange struct {
+	ArtifactLocation ArtifactLocation `json:"artifactLocation"`
+	Replacements     []Replacement    `json:"replacements"`
+}
+
+// Replacement represents the replacement of a single region.
+type Replacement struct {
+	DeletedRegion   Region           `json:"deletedRegion"`
+	InsertedContent *ArtifactContent `json:"insertedContent,omitempty"`
+}
+
+// ArtifactContent represents the content to insert.
+type ArtifactContent struct {
+	Text string `json:"text"`
 }
 
 // Message contains text describing a result or rule.


### PR DESCRIPTION
Add fixes field to SARIF output to support reviewdog's suggestion feature. When NewLine is available, the fix suggestion is included in the SARIF output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
