### PR TITLE
fix: fix some bugs

### DIFF
--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -267,59 +267,74 @@ func compareVersion(currentVersion, newVersion string) bool {
 // commit SHAs match their corresponding version tags.
 func (c *Controller) parseSemverTagLine(ctx context.Context, logger *slog.Logger, action *Action) (string, error) {
 	// @xxx # v3.0.0
-	if c.param.Update { //nolint:nestif
-		// get the latest version
-		lv, err := c.getLatestVersion(ctx, logger, action.RepoOwner, action.RepoName, action.VersionComment)
+	if c.param.Update {
+		return c.parseSemverTagLineUpdate(ctx, logger, action)
+	}
+	return c.parseSemverTagLinePin(ctx, logger, action)
+}
+
+// parseSemverTagLineUpdate handles the update case for semver tag lines.
+func (c *Controller) parseSemverTagLineUpdate(ctx context.Context, logger *slog.Logger, action *Action) (string, error) {
+	lv, err := c.getLatestVersion(ctx, logger, action.RepoOwner, action.RepoName, action.VersionComment)
+	if err != nil {
+		return "", fmt.Errorf("get the latest version: %w", err)
+	}
+	if action.VersionComment == lv {
+		return c.handleCurrentVersionIsLatest(ctx, logger, action, lv)
+	}
+	return c.handleUpdateToNewerVersion(ctx, logger, action, lv)
+}
+
+// handleCurrentVersionIsLatest handles when the current version comment matches the latest version.
+func (c *Controller) handleCurrentVersionIsLatest(ctx context.Context, logger *slog.Logger, action *Action, lv string) (string, error) {
+	switch getVersionType(action.Version) {
+	case Semver, Shortsemver:
+		sha, _, err := c.repositoriesService.GetCommitSHA1(ctx, logger, action.RepoOwner, action.RepoName, lv, "")
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)
 		}
-		if action.VersionComment == lv {
-			switch getVersionType(action.Version) {
-			case Semver, Shortsemver:
-				sha, _, err := c.repositoriesService.GetCommitSHA1(ctx, logger, action.RepoOwner, action.RepoName, lv, "")
-				if err != nil {
-					return "", fmt.Errorf("get the latest version: %w", err)
-				}
-				return patchLine(action, sha, lv), nil
-			case FullCommitSHA:
-				if c.param.IsVerify {
-					// verify commit hash
-					if err := c.verify(ctx, logger, action); err != nil {
-						return "", fmt.Errorf("verify the version annotation: %w", err)
-					}
-				}
-				return "", nil
-			}
-			return "", ErrCantPinned
-		}
-		if !compareVersion(action.VersionComment, lv) {
-			logger.Warn("skip updating because the current version is newer than the new version",
-				"current_version", action.VersionComment,
-				"new_version", lv,
-			)
-			return "", nil
-		}
-		if action.VersionComment != lv {
-			sha, _, err := c.repositoriesService.GetCommitSHA1(ctx, logger, action.RepoOwner, action.RepoName, lv, "")
-			if err != nil {
-				return "", fmt.Errorf("get the latest version: %w", err)
-			}
-			return patchLine(action, sha, lv), nil
-		}
+		return patchLine(action, sha, lv), nil
+	case FullCommitSHA:
+		return c.verifyIfNeeded(ctx, logger, action)
 	}
+	return "", ErrCantPinned
+}
+
+// handleUpdateToNewerVersion handles updating to a newer version when available.
+func (c *Controller) handleUpdateToNewerVersion(ctx context.Context, logger *slog.Logger, action *Action, lv string) (string, error) {
+	if !compareVersion(action.VersionComment, lv) {
+		logger.Warn("skip updating because the current version is newer than the new version",
+			"current_version", action.VersionComment,
+			"new_version", lv,
+		)
+		return "", nil
+	}
+	sha, _, err := c.repositoriesService.GetCommitSHA1(ctx, logger, action.RepoOwner, action.RepoName, lv, "")
+	if err != nil {
+		return "", fmt.Errorf("get the latest version: %w", err)
+	}
+	return patchLine(action, sha, lv), nil
+}
+
+// parseSemverTagLinePin handles the pin case for semver tag lines.
+func (c *Controller) parseSemverTagLinePin(ctx context.Context, logger *slog.Logger, action *Action) (string, error) {
 	switch typ := getVersionType(action.Version); typ {
 	case Semver, Shortsemver:
 		return c.pinCurrentVersion(ctx, logger, action, typ)
 	case FullCommitSHA:
-		if c.param.IsVerify {
-			// verify commit hash
-			if err := c.verify(ctx, logger, action); err != nil {
-				return "", fmt.Errorf("verify the version annotation: %w", err)
-			}
-		}
-		return "", nil
+		return c.verifyIfNeeded(ctx, logger, action)
 	}
 	return "", ErrCantPinned
+}
+
+// verifyIfNeeded verifies the commit hash if verification is enabled.
+func (c *Controller) verifyIfNeeded(ctx context.Context, logger *slog.Logger, action *Action) (string, error) {
+	if c.param.IsVerify {
+		if err := c.verify(ctx, logger, action); err != nil {
+			return "", fmt.Errorf("verify the version annotation: %w", err)
+		}
+	}
+	return "", nil
 }
 
 // parseShortSemverTagLine processes actions with short semantic version comments.


### PR DESCRIPTION
1. `-verify` is ignored if `-u` is used
2. version isn't pinned and verified if version comment is semver

number | code | command | before | after
--- | --- | --- | --- | ---
1 | `uses: actions/checkout@v6.0.1 # v6.0.1` | `pinact run -u` | Not pinned | Pinned
2 | `uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.1` | `pinact run -u -verify` | success | failure `action_version must be equal to commit_hash_of_version_annotation`
3 | `uses: actions/checkout@v6.0.1 # v6.0.1` | `pinact run`, `pinact run -verify` | Not pinned | Pinned
4 | `uses: actions/checkout@main # v6.0.1` | `pinact run`, `pinact run -verify` | success | failure `action can't be pinned`