### PR TITLE
docs: fix readme for ignore_actions[].ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ This is required.
 A regular expression of ignored action versions (branch, tag, or commit hash).
 
 > [!WARNING]
-> Regular expressions must match with action names exactly.
+> Regular expressions must match with action versions exactly.
 > For instance, `ref: main` doesn't match with `malicious-main`
 
 #### `ghes`


### PR DESCRIPTION
The explanation is `ignore_actions[].name`. maybe just copy&pasted?

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: too small documentation fix so I didn't
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

<!-- Please write the description here -->
