### PR TITLE
docs: fix readme for correct GHES_API_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,15 +600,15 @@ ghes:
 
 You can also configure GHES using environment variables instead of a configuration file.
 
-- `PINACT_GHES_API_URL`
+- `GHES_API_URL`
 - `PINACT_GHES_FALLBACK`
 
 ```sh
-export PINACT_GHES_API_URL=https://ghes.example.com
+export GHES_API_URL=https://ghes.example.com
 export PINACT_GHES_FALLBACK=true
 ```
 
-If `PINACT_GHES_API_URL` is not set, `GITHUB_API_URL` will be used instead.
+If `GHES_API_URL` is not set, `GITHUB_API_URL` will be used instead.
 This is convenient when running on GitHub Actions hosted on GHES.
 
 ### Conditions for Enabling GHES
@@ -616,7 +616,7 @@ This is convenient when running on GitHub Actions hosted on GHES.
 GHES mode is enabled when any of the following conditions are met:
 
 1. `ghes.api_url` is configured in the configuration file
-2. `PINACT_GHES_API_URL` environment variable is set
+2. `GHES_API_URL` environment variable is set
 3. `GITHUB_API_URL` environment variable is set and is not `https://api.github.com`
 
 ## See also


### PR DESCRIPTION
This PR fixes wrong env variable for GHE.
https://github.com/suzuki-shunsuke/pinact/blob/main/pkg/di/env.go#L28

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua/blob/main/CONTRIBUTING.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

<!-- Please write the description here -->
