### PR TITLE
fix: prefer tag namespace over branch when resolving @vX refs

### DIFF
--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -18,6 +18,7 @@ type RepositoriesService interface {
 	ListTags(ctx context.Context, logger *slog.Logger, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
 	ListReleases(ctx context.Context, logger *slog.Logger, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
 	GetCommitSHA1(ctx context.Context, logger *slog.Logger, owner, repo, ref, lastSHA string) (string, *github.Response, error)
+	ResolveCommitSHAPreferTag(ctx context.Context, logger *slog.Logger, owner, repo, ref string) (string, bool, error)
 }
 
 // GitService defines the interface for GitHub Git API operations

--- a/pkg/controller/run/github_internal_test.go
+++ b/pkg/controller/run/github_internal_test.go
@@ -171,6 +171,10 @@ func (m *mockRepoService) GetCommitSHA1(_ context.Context, _, _, _, _ string) (s
 	return "", nil, errors.New("not implemented")
 }
 
+func (m *mockRepoService) ResolveCommitSHAPreferTag(_ context.Context, _ *slog.Logger, _, _, _ string) (string, bool, error) {
+	return "", false, errors.New("not implemented")
+}
+
 func (m *mockRepoService) ListReleases(ctx context.Context, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {
 	if m.listReleasesFunc != nil {
 		return m.listReleasesFunc(ctx, owner, repo, opts)

--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -219,7 +219,7 @@ func (c *Controller) updateToLatestVersion(ctx context.Context, logger *slog.Log
 	if err != nil {
 		return "", fmt.Errorf("get the latest version: %w", err)
 	}
-	sha, _, err := c.repositoriesService.GetCommitSHA1(ctx, logger, action.RepoOwner, action.RepoName, lv, "")
+	sha, _, err := c.repositoriesService.ResolveCommitSHAPreferTag(ctx, logger, action.RepoOwner, action.RepoName, lv)
 	if err != nil {
 		return "", fmt.Errorf("get a reference: %w", err)
 	}
@@ -228,9 +228,9 @@ func (c *Controller) updateToLatestVersion(ctx context.Context, logger *slog.Log
 
 // pinCurrentVersion pins the current version to a commit SHA.
 func (c *Controller) pinCurrentVersion(ctx context.Context, logger *slog.Logger, action *Action, typ VersionType) (string, error) {
-	// Get commit hash from tag
-	// https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#get-a-reference
-	sha, _, err := c.repositoriesService.GetCommitSHA1(ctx, logger, action.RepoOwner, action.RepoName, action.Version, "")
+	// Get commit hash from tag, preferring the tag namespace over any branch
+	// of the same name so the pin matches what the Actions runtime executes.
+	sha, _, err := c.repositoriesService.ResolveCommitSHAPreferTag(ctx, logger, action.RepoOwner, action.RepoName, action.Version)
 	if err != nil {
 		return "", fmt.Errorf("get a reference: %w", err)
 	}
@@ -289,7 +289,7 @@ func (c *Controller) parseSemverTagLineUpdate(ctx context.Context, logger *slog.
 func (c *Controller) handleCurrentVersionIsLatest(ctx context.Context, logger *slog.Logger, action *Action, lv string) (string, error) {
 	switch getVersionType(action.Version) {
 	case Semver, Shortsemver:
-		sha, _, err := c.repositoriesService.GetCommitSHA1(ctx, logger, action.RepoOwner, action.RepoName, lv, "")
+		sha, _, err := c.repositoriesService.ResolveCommitSHAPreferTag(ctx, logger, action.RepoOwner, action.RepoName, lv)
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)
 		}
@@ -309,7 +309,7 @@ func (c *Controller) handleUpdateToNewerVersion(ctx context.Context, logger *slo
 		)
 		return "", nil
 	}
-	sha, _, err := c.repositoriesService.GetCommitSHA1(ctx, logger, action.RepoOwner, action.RepoName, lv, "")
+	sha, _, err := c.repositoriesService.ResolveCommitSHAPreferTag(ctx, logger, action.RepoOwner, action.RepoName, lv)
 	if err != nil {
 		return "", fmt.Errorf("get the latest version: %w", err)
 	}
@@ -351,7 +351,7 @@ func (c *Controller) parseShortSemverTagLine(ctx context.Context, logger *slog.L
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)
 		}
-		sha, _, err := c.repositoriesService.GetCommitSHA1(ctx, logger, action.RepoOwner, action.RepoName, lv, "")
+		sha, _, err := c.repositoriesService.ResolveCommitSHAPreferTag(ctx, logger, action.RepoOwner, action.RepoName, lv)
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)
 		}
@@ -437,9 +437,15 @@ func (c *Controller) parseActionName(action *Action) bool {
 // It validates that the commit SHA in the action version matches the
 // commit SHA of the version specified in the comment.
 func (c *Controller) verify(ctx context.Context, logger *slog.Logger, action *Action) error {
-	sha, _, err := c.repositoriesService.GetCommitSHA1(ctx, logger, action.RepoOwner, action.RepoName, action.VersionComment, "")
+	sha, fromTag, err := c.repositoriesService.ResolveCommitSHAPreferTag(ctx, logger, action.RepoOwner, action.RepoName, action.VersionComment)
 	if err != nil {
 		return fmt.Errorf("get a commit hash: %w", err)
+	}
+	if !fromTag {
+		logger.Warn("version annotation resolved via a branch, not a tag; GitHub Actions resolves @ref to a tag first at runtime, so this pin may diverge from what Actions executes if a tag of the same name is later published",
+			"action", action.Name,
+			"version_annotation", action.VersionComment,
+		)
 	}
 	if action.Version == sha {
 		return nil

--- a/pkg/controller/run/parse_line_internal_test.go
+++ b/pkg/controller/run/parse_line_internal_test.go
@@ -149,6 +149,13 @@ func TestController_parseLine(t *testing.T) { //nolint:funlen
 			line: `  "uses": 'actions/checkout@v2'`,
 			exp:  `  "uses": 'actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5' # v2.7.0`,
 		},
+		{
+			// Repo with both a v1 tag and v1 branch pointing at different SHAs.
+			// pinact must pin to the tag SHA to match Actions runtime resolution.
+			name: "ambiguous ref with tag and branch - tag wins",
+			line: "  - uses: example-owner/example-action@v1",
+			exp:  "  - uses: example-owner/example-action@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v1.2.3",
+		},
 	}
 	logger := slog.New(slog.DiscardHandler)
 	for _, d := range data {
@@ -186,19 +193,47 @@ func TestController_parseLine(t *testing.T) { //nolint:funlen
 						},
 						Response: &github.Response{},
 					},
+					"example-owner/example-action/0": {
+						Tags: []*github.RepositoryTag{
+							{
+								Name: new("v1"),
+								Commit: &github.Commit{
+									SHA: new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+								},
+							},
+							{
+								Name: new("v1.2.3"),
+								Commit: &github.Commit{
+									SHA: new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+								},
+							},
+						},
+						Response: &github.Response{},
+					},
 				},
 				Releases: map[string]*github.ListReleasesResult{
 					"actions/checkout/0": {
 						Releases: []*github.RepositoryRelease{}, // Empty releases forces fallback to tags
 						Response: &github.Response{},
 					},
+					"example-owner/example-action/0": {
+						Releases: []*github.RepositoryRelease{},
+						Response: &github.Response{},
+					},
 				},
 				Commits: map[string]*github.GetCommitSHA1Result{
-					"actions/checkout/v3": {
+					"actions/checkout/tags/v3": {
 						SHA: "8e5e7e5ab8b370d6c329ec480221332ada57f0ab",
 					},
-					"actions/checkout/v2": {
+					"actions/checkout/tags/v2": {
 						SHA: "ee0669bd1cc54295c223e0bb666b733df41de1c5",
+					},
+					// Both tag and branch entries seeded — the branch SHA must NOT be used.
+					"example-owner/example-action/tags/v1": {
+						SHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					},
+					"example-owner/example-action/v1": {
+						SHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 					},
 				},
 			}, nil, nil, fs, &config.Config{

--- a/pkg/github/service.go
+++ b/pkg/github/service.go
@@ -234,6 +234,44 @@ func (r *RepositoriesServiceImpl) GetCommitSHA1(ctx context.Context, logger *slo
 	return sha, resp, err
 }
 
+// ResolveCommitSHAPreferTag resolves a git ref to a commit SHA, preferring the
+// tag namespace when both a tag and branch share the same name.
+//
+// GitHub's /commits/{ref} endpoint follows git's native precedence — branches
+// before tags when the name is ambiguous — but the GitHub Actions runner
+// resolves @ref to a tag before a branch. Pinning via the bare endpoint would
+// therefore diverge from what Actions executes at runtime. We query the tag
+// namespace explicitly (tags/<ref>) first and fall back to the bare ref only
+// on 404 so that branch-only refs (e.g. a repo with a v1 branch but no v1 tag)
+// keep resolving.
+//
+// The second return value reports whether the SHA came from the tag namespace.
+func (r *RepositoriesServiceImpl) ResolveCommitSHAPreferTag(ctx context.Context, logger *slog.Logger, owner, repo, ref string) (string, bool, error) {
+	sha, resp, err := r.GetCommitSHA1(ctx, logger, owner, repo, "tags/"+ref, "")
+	if err == nil {
+		return sha, true, nil
+	}
+	if !isNotFoundResponse(resp) {
+		return "", false, err
+	}
+	logger.Debug("no matching tag; falling back to bare ref", "owner", owner, "repo", repo, "ref", ref)
+	sha, _, err = r.GetCommitSHA1(ctx, logger, owner, repo, ref, "")
+	if err != nil {
+		return "", false, err
+	}
+	return sha, false, nil
+}
+
+// isNotFoundResponse reports whether a GitHub API response indicates 404.
+// The embedded *http.Response can be nil in tests or on transport errors, so we
+// guard before reading StatusCode.
+func isNotFoundResponse(resp *Response) bool {
+	if resp == nil || resp.Response == nil {
+		return false
+	}
+	return resp.StatusCode == http.StatusNotFound
+}
+
 // GetCommitSHA1Result holds the cached result of a GetCommitSHA1 call.
 type GetCommitSHA1Result struct {
 	SHA      string

--- a/pkg/github/service_internal_test.go
+++ b/pkg/github/service_internal_test.go
@@ -1,0 +1,132 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"testing"
+)
+
+// TestRepositoriesServiceImpl_ResolveCommitSHAPreferTag covers the branch-vs-tag
+// precedence fix: when a ref exists as both a tag and a branch, pinact must
+// resolve to the tag to match what GitHub Actions executes at runtime.
+func TestRepositoriesServiceImpl_ResolveCommitSHAPreferTag(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := slog.New(slog.DiscardHandler)
+
+	notFound := &Response{Response: &http.Response{StatusCode: http.StatusNotFound}}
+	serverErr := &Response{Response: &http.Response{StatusCode: http.StatusInternalServerError}}
+
+	tests := []struct {
+		name        string
+		owner       string
+		repo        string
+		ref         string
+		cache       map[string]*GetCommitSHA1Result
+		wantSHA     string
+		wantFromTag bool
+		wantErr     bool
+	}{
+		{
+			name:  "tag only - resolves via tag namespace",
+			owner: "actions",
+			repo:  "checkout",
+			ref:   "v3",
+			cache: map[string]*GetCommitSHA1Result{
+				"actions/checkout/tags/v3": {SHA: "tagSHA"},
+			},
+			wantSHA:     "tagSHA",
+			wantFromTag: true,
+		},
+		{
+			name:  "branch only - falls back after 404 on tag namespace",
+			owner: "allenheltondev",
+			repo:  "detect-breaking-changes-action",
+			ref:   "v1",
+			cache: map[string]*GetCommitSHA1Result{
+				"allenheltondev/detect-breaking-changes-action/tags/v1": {
+					Response: notFound,
+					err:      errors.New("404 Not Found"),
+				},
+				"allenheltondev/detect-breaking-changes-action/v1": {SHA: "branchSHA"},
+			},
+			wantSHA:     "branchSHA",
+			wantFromTag: false,
+		},
+		{
+			name:  "diverged tag and branch - tag wins",
+			owner: "peter-evans",
+			repo:  "slash-command-dispatch",
+			ref:   "v5",
+			cache: map[string]*GetCommitSHA1Result{
+				"peter-evans/slash-command-dispatch/v5":      {SHA: "0683e68c"},
+				"peter-evans/slash-command-dispatch/tags/v5": {SHA: "9bdcd791"},
+			},
+			wantSHA:     "9bdcd791",
+			wantFromTag: true,
+		},
+		{
+			name:  "branch is ancestor of tag - tag still wins",
+			owner: "thollander",
+			repo:  "actions-comment-pull-request",
+			ref:   "v3",
+			cache: map[string]*GetCommitSHA1Result{
+				"thollander/actions-comment-pull-request/v3":      {SHA: "65f9e5c9"},
+				"thollander/actions-comment-pull-request/tags/v3": {SHA: "24bffb9b"},
+			},
+			wantSHA:     "24bffb9b",
+			wantFromTag: true,
+		},
+		{
+			name:  "non-404 error on tag lookup - propagates without fallback",
+			owner: "owner",
+			repo:  "repo",
+			ref:   "v1",
+			cache: map[string]*GetCommitSHA1Result{
+				"owner/repo/tags/v1": {
+					Response: serverErr,
+					err:      errors.New("500 Internal Server Error"),
+				},
+				"owner/repo/v1": {SHA: "branchSHA"},
+			},
+			wantErr: true,
+		},
+		{
+			name:  "both lookups 404 - propagates error from fallback",
+			owner: "nobody",
+			repo:  "nothing",
+			ref:   "v9",
+			cache: map[string]*GetCommitSHA1Result{
+				"nobody/nothing/tags/v9": {Response: notFound, err: errors.New("404 Not Found")},
+				"nobody/nothing/v9":      {Response: notFound, err: errors.New("404 Not Found")},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := &RepositoriesServiceImpl{Commits: tt.cache}
+
+			sha, fromTag, err := r.ResolveCommitSHAPreferTag(ctx, logger, tt.owner, tt.repo, tt.ref)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ResolveCommitSHAPreferTag() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if sha != tt.wantSHA {
+				t.Errorf("sha = %q, want %q", sha, tt.wantSHA)
+			}
+			if fromTag != tt.wantFromTag {
+				t.Errorf("fromTag = %v, want %v", fromTag, tt.wantFromTag)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1477.

When a target repo has both a branch and a tag with the same name, pinact was resolving to the branch SHA while the GitHub Actions runner resolves to the tag. The pinned SHA diverged from what Actions executes at runtime.

This PR adds `RepositoriesServiceImpl.ResolveCommitSHAPreferTag` which queries `tags/<ref>` first and falls back to the bare ref on 404, so branch-only refs (e.g. actions that ship a `v1` branch but no `v1` tag) continue to resolve. All six `GetCommitSHA1` call sites in `pkg/controller/run/parse_line.go` now go through the helper; `verify` additionally warns when a version annotation resolves via the branch fallback rather than a tag.

## Approach note

Issue #1477 mentioned two plausible shapes — the `tags/<ref>` prefix approach taken here, and an alternative that consults the already-populated `ListTags` cache. I went with the former because it's simpler, doesn't depend on cache ordering, and keeps a single code path for github.com and GHES callers. Happy to redirect if you'd prefer the cache-based variant — the service-level abstraction keeps the implementation swappable.

## Cost

One extra round-trip per unique branch-only ref, cached thereafter (O(1) per ref per run). Acceptable trade-off for correctness; open to suggestions if this is a concern.

## Tests

- `TestRepositoriesServiceImpl_ResolveCommitSHAPreferTag` covers six scenarios: tag-only, branch-only 404 fallback, diverged tag/branch, branch-ancestor-of-tag, non-404 error propagation, and dual 404.
- `TestController_parseLine` gains an integration case seeding both tag and branch SHAs in the cache to verify the tag wins end-to-end through `parseLine`.
- Existing test fixtures updated to use `tags/vX` cache keys.

## Test plan

- [ ] `cmdx t` / `go test ./...` — passes locally.
- [ ] `cmdx v` / `go vet ./...` — clean locally.
- [ ] `cmdx l` / `golangci-lint run` — 0 issues locally against pinned `v2.11.4`.

---

*Implementation produced collaboratively with Claude Code (AI assistant); changes reviewed against `go test`, `go vet`, and `golangci-lint` before push. Happy to iterate on maintainer feedback.*