### PR TITLE
feat: warn archived repo

### DIFF
--- a/pkg/di/ghes.go
+++ b/pkg/di/ghes.go
@@ -48,9 +48,10 @@ func setupGHESServices(ctx context.Context, gh *github.Client, cfg *config.Confi
 	)
 
 	repoService := &github.RepositoriesServiceImpl{
-		Tags:     map[string]*github.ListTagsResult{},
-		Releases: map[string]*github.ListReleasesResult{},
-		Commits:  map[string]*github.GetCommitSHA1Result{},
+		Tags:         map[string]*github.ListTagsResult{},
+		Releases:     map[string]*github.ListReleasesResult{},
+		Commits:      map[string]*github.GetCommitSHA1Result{},
+		CheckedRepos: map[string]struct{}{},
 	}
 	repoService.SetResolver(resolver)
 

--- a/pkg/github/service.go
+++ b/pkg/github/service.go
@@ -198,15 +198,37 @@ type ListReleasesResult struct {
 
 // RepositoriesServiceImpl wraps a RepositoriesService with caching and GHES fallback support.
 type RepositoriesServiceImpl struct {
-	resolver *ClientResolver
-	Tags     map[string]*ListTagsResult
-	Commits  map[string]*GetCommitSHA1Result
-	Releases map[string]*ListReleasesResult
+	resolver     *ClientResolver
+	Tags         map[string]*ListTagsResult
+	Commits      map[string]*GetCommitSHA1Result
+	Releases     map[string]*ListReleasesResult
+	CheckedRepos map[string]struct{}
 }
 
 // SetResolver sets the ClientResolver for the RepositoriesServiceImpl.
 func (r *RepositoriesServiceImpl) SetResolver(resolver *ClientResolver) {
 	r.resolver = resolver
+}
+
+// warnIfArchived checks if a repository is archived and logs a warning if so.
+// It caches the result per repository to avoid redundant API calls.
+func (r *RepositoriesServiceImpl) warnIfArchived(ctx context.Context, logger *slog.Logger, owner, repo string) {
+	key := owner + "/" + repo
+	if _, ok := r.CheckedRepos[key]; ok {
+		return
+	}
+	r.CheckedRepos[key] = struct{}{}
+	service, err := r.resolver.GetRepositoriesService(ctx, logger, owner, repo)
+	if err != nil {
+		return
+	}
+	ghRepo, _, err := service.Get(ctx, owner, repo)
+	if err != nil {
+		return
+	}
+	if ghRepo.GetArchived() {
+		logger.Warn("repository is archived", "owner", owner, "repo", repo)
+	}
 }
 
 // Get fetches a repository to check its existence.
@@ -220,6 +242,7 @@ func (r *RepositoriesServiceImpl) Get(ctx context.Context, logger *slog.Logger, 
 
 // GetCommitSHA1 retrieves the commit SHA for a given reference with caching and GHES fallback.
 func (r *RepositoriesServiceImpl) GetCommitSHA1(ctx context.Context, logger *slog.Logger, owner, repo, ref, lastSHA string) (string, *Response, error) {
+	r.warnIfArchived(ctx, logger, owner, repo)
 	key := fmt.Sprintf("%s/%s/%s", owner, repo, ref)
 	if result, ok := r.Commits[key]; ok {
 		return result.SHA, result.Response, result.err
@@ -243,6 +266,7 @@ type GetCommitSHA1Result struct {
 
 // ListTags retrieves repository tags with caching and GHES fallback.
 func (r *RepositoriesServiceImpl) ListTags(ctx context.Context, logger *slog.Logger, owner string, repo string, opts *ListOptions) ([]*RepositoryTag, *Response, error) {
+	r.warnIfArchived(ctx, logger, owner, repo)
 	key := fmt.Sprintf("%s/%s/%v", owner, repo, opts.Page)
 	if result, ok := r.Tags[key]; ok {
 		return result.Tags, result.Response, result.err
@@ -259,6 +283,7 @@ func (r *RepositoriesServiceImpl) ListTags(ctx context.Context, logger *slog.Log
 
 // ListReleases retrieves repository releases with caching and GHES fallback.
 func (r *RepositoriesServiceImpl) ListReleases(ctx context.Context, logger *slog.Logger, owner string, repo string, opts *ListOptions) ([]*RepositoryRelease, *Response, error) {
+	r.warnIfArchived(ctx, logger, owner, repo)
 	key := fmt.Sprintf("%s/%s/%v", owner, repo, opts.Page)
 	if result, ok := r.Releases[key]; ok {
 		return result.Releases, result.Response, result.err

--- a/testdata/actions/unmaintained-action.yaml
+++ b/testdata/actions/unmaintained-action.yaml
@@ -1,0 +1,9 @@
+name: Release
+description: Release
+on:
+  push:
+    tags:
+      - "v*.*.*"
+runs:
+  steps:
+    - uses: actions/create-release@8d93430eddafb926c668181c71f579556f68668c # v1.0.0


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
  - Outdated. See #1490  
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: #1488 
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

<!-- Please write the description here -->

Add a warning log when pinact processes an action whose repository has been archived on GitHub.

```shellsession
❯ cmdx run -- run -u --log-level warn testdata/actions/unmaintained-action.yaml
+ go run ./cmd/pinact run -u testdata/actions/unmaintained-action.yaml

Apr 26 11:45:37.374 WRN repository is archived program=pinact version="" workflow_file=testdata/actions/unmaintained-action.yaml line_number=9 line="    - uses: actions/create-release@8d93430eddafb926c668181c71f579556f68668c # v1.0.0" action=actions/create-release@8d93430eddafb926c668181c71f579556f68668c owner=actions repo=create-release
```

This change adds one extra `GET /repos/{owner}/{repo}` API call per unique repository. The result is cached in `CheckedRepos` so that subsequent calls for the same repository (e.g. multiple tags/refs being resolved in the same run) do not trigger additional requests.

Since this will increase the number of API calls, we could implement an option to use an opt-in/opt-out system, but personally, I’d prefer it to be enabled by default.

---

I found an unused function. Should it be removed, or is it implicitly referenced?

https://github.com/suzuki-shunsuke/pinact/blob/1cad732e2d1dab84216c3a940f4f9c439532ce02/pkg/github/service.go#L212-L219