### PR TITLE
feat: add `updates.min_age` to config files

### DIFF
--- a/json-schema/pinact.json
+++ b/json-schema/pinact.json
@@ -30,6 +30,10 @@
           "$ref": "#/$defs/GHES",
           "description": "GitHub Enterprise Server configuration"
         },
+        "updates": {
+          "$ref": "#/$defs/Updates",
+          "description": "Update behavior configuration"
+        },
         "separator": {
           "type": "string",
           "description": "Separator between version and tag comment. Default is ' # '"
@@ -78,6 +82,16 @@
       "required": [
         "name"
       ]
+    },
+    "Updates": {
+      "properties": {
+        "min_age": {
+          "type": "integer",
+          "description": "Skip versions released within the specified number of days. Default is 0"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     }
   }
 }

--- a/pkg/cli/run/command.go
+++ b/pkg/cli/run/command.go
@@ -12,8 +12,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/suzuki-shunsuke/pinact/v3/pkg/cli/gflag"
+	"github.com/suzuki-shunsuke/pinact/v3/pkg/config"
 	"github.com/suzuki-shunsuke/pinact/v3/pkg/di"
 	"github.com/suzuki-shunsuke/slog-util/slogutil"
 	"github.com/suzuki-shunsuke/urfave-cli-v3-util/urfave"
@@ -146,9 +148,11 @@ $ pinact run .github/actions/foo/action.yaml .github/actions/bar/action.yaml
 				Usage:       "Skip versions released within the specified number of days (requires -u)",
 				Destination: &flags.MinAge,
 				Sources:     cli.EnvVars("PINACT_MIN_AGE"),
+				Value:       0,
+				DefaultText: strconv.Itoa(config.DefaultMinAge),
 				Validator: func(i int) error {
-					if i < 0 {
-						return errors.New("--min-age must be a non-negative integer")
+					if err := config.ValidateMinAge(i); err != nil {
+						return fmt.Errorf("--min-age: %w", err)
 					}
 					return nil
 				},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Files         []*File         `json:"files,omitempty" jsonschema:"description=Target files. If files are passed via positional command line arguments, this is ignored"`
 	IgnoreActions []*IgnoreAction `json:"ignore_actions,omitempty" yaml:"ignore_actions" jsonschema:"description=Actions and reusable workflows that pinact ignores"`
 	GHES          *GHES           `json:"ghes,omitempty" yaml:"ghes" jsonschema:"description=GitHub Enterprise Server configuration"`
+	Updates       *Updates        `json:"updates,omitempty" yaml:"updates" jsonschema:"description=Update behavior configuration"`
 	Separator     string          `json:"separator,omitempty" jsonschema:"description=Separator between version and tag comment. Default is ' # '"`
 }
 
@@ -33,6 +34,23 @@ type GHES struct {
 
 type File struct {
 	Pattern string `json:"pattern"`
+}
+
+// DefaultMinAge is the default minimum age in days for updates.
+// A value of 0 means no minimum age filter is applied.
+const DefaultMinAge = 0
+
+type Updates struct {
+	MinAge int `json:"min_age,omitempty" yaml:"min_age" jsonschema:"description=Skip versions released within the specified number of days. Default is 0"`
+}
+
+// EnsureUpdates returns the updates configuration.
+// If the updates configuration is nil, it initializes it.
+func (cfg *Config) EnsureUpdates() *Updates {
+	if cfg.Updates == nil {
+		cfg.Updates = &Updates{}
+	}
+	return cfg.Updates
 }
 
 var (
@@ -66,6 +84,20 @@ func validateSchemaVersion(v int) error {
 			"docs", "https://github.com/suzuki-shunsuke/pinact/blob/main/docs/codes/004.md",
 		)
 	}
+}
+
+// ValidateMinAge validates the minimum age for updates.
+// The value must be a non-negative integer.
+//
+// Parameters:
+//   - age: minimum age in days
+//
+// Returns an error if the value is invalid.
+func ValidateMinAge(age int) error {
+	if age < 0 {
+		return errors.New("min_age must be a non-negative integer")
+	}
+	return nil
 }
 
 // Init initializes and validates a File configuration.
@@ -221,6 +253,17 @@ func (g *GHES) Validate() error {
 	return nil
 }
 
+// Validate validates the ensures update settings are valid.
+func (u *Updates) Validate() error {
+	if u == nil {
+		return nil
+	}
+	if err := ValidateMinAge(u.MinAge); err != nil {
+		return fmt.Errorf("updates min_age: %w", err)
+	}
+	return nil
+}
+
 // getConfigPath searches for a pinact configuration file in standard locations.
 // It checks for .pinact.yaml, .github/pinact.yaml, .pinact.yml, and .github/pinact.yml
 // in order of preference.
@@ -293,6 +336,9 @@ func (r *Reader) Read(cfg *Config, configFilePath string) error {
 func (cfg *Config) Init() error {
 	if err := validateSchemaVersion(cfg.Version); err != nil {
 		return err
+	}
+	if err := cfg.Updates.Validate(); err != nil {
+		return fmt.Errorf("validate updates: %w", err)
 	}
 	for _, file := range cfg.Files {
 		if err := file.Init(cfg.Version); err != nil {

--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -135,6 +135,56 @@ func TestGHES_Validate(t *testing.T) {
 	}
 }
 
+func TestValidateMinAge(t *testing.T) {
+	t.Parallel()
+	data := []struct {
+		name    string
+		minAge  int
+		wantErr bool
+	}{
+		{name: "default", minAge: DefaultMinAge, wantErr: false},
+		{name: "positive", minAge: 30, wantErr: false},
+		{name: "negative", minAge: -1, wantErr: true},
+	}
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateMinAge(d.minAge)
+			if d.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !d.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestUpdates_Validate(t *testing.T) {
+	t.Parallel()
+	data := []struct {
+		name    string
+		updates *Updates
+		wantErr bool
+	}{
+		{name: "nil", updates: nil, wantErr: false},
+		{name: "valid", updates: &Updates{MinAge: 14}, wantErr: false},
+		{name: "invalid", updates: &Updates{MinAge: -1}, wantErr: true},
+	}
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			err := d.updates.Validate()
+			if d.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !d.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestFinder_Find(t *testing.T) {
 	t.Parallel()
 	t.Run("explicit path", func(t *testing.T) {
@@ -167,6 +217,7 @@ func TestFinder_Find(t *testing.T) {
 	})
 }
 
+//nolint:funlen,cyclop
 func TestReader_Read(t *testing.T) {
 	t.Parallel()
 	t.Run("empty path", func(t *testing.T) {
@@ -199,6 +250,46 @@ files:
 		}
 		if len(cfg.Files) != 1 {
 			t.Errorf("Files length: wanted 1, got %d", len(cfg.Files))
+		}
+	})
+
+	t.Run("valid config with updates", func(t *testing.T) {
+		t.Parallel()
+		fs := afero.NewMemMapFs()
+		content := `version: 3
+updates:
+  min_age: 14
+`
+		if err := afero.WriteFile(fs, ".pinact.yaml", []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		reader := NewReader(fs)
+		cfg := &Config{}
+		if err := reader.Read(cfg, ".pinact.yaml"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Updates == nil {
+			t.Fatal("Updates: wanted non-nil, got nil")
+		}
+		if cfg.Updates.MinAge != 14 {
+			t.Errorf("Updates.MinAge: wanted 14, got %d", cfg.Updates.MinAge)
+		}
+	})
+
+	t.Run("invalid updates min_age", func(t *testing.T) {
+		t.Parallel()
+		fs := afero.NewMemMapFs()
+		content := `version: 3
+updates:
+  min_age: -1
+`
+		if err := afero.WriteFile(fs, ".pinact.yaml", []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		reader := NewReader(fs)
+		cfg := &Config{}
+		if err := reader.Read(cfg, ".pinact.yaml"); err == nil {
+			t.Error("expected error, got nil")
 		}
 	})
 

--- a/pkg/controller/initcmd/init.go
+++ b/pkg/controller/initcmd/init.go
@@ -24,6 +24,9 @@ ignore_actions:
 #   ref: main
 # - name: suzuki-shunsuke/.*
 #   ref: release-.*
+
+updates:
+#  min_age: 21
 `
 	filePermission os.FileMode = 0o644
 )

--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -34,8 +34,8 @@ func (c *Controller) getLatestVersion(ctx context.Context, logger *slog.Logger, 
 
 	// Calculate cutoff once for min-age filtering
 	var cutoff time.Time
-	if c.param.MinAge > 0 {
-		cutoff = c.param.Now.AddDate(0, 0, -c.param.MinAge)
+	if c.cfg.Updates.MinAge > 0 {
+		cutoff = c.param.Now.AddDate(0, 0, -c.cfg.Updates.MinAge)
 	}
 
 	lv, versions, err := c.getLatestVersionFromReleases(ctx, logger, owner, repo, isStable, cutoff)
@@ -102,7 +102,8 @@ func (c *Controller) getLatestVersionFromReleases(ctx context.Context, logger *s
 		if !cutoff.IsZero() && release.GetPublishedAt().After(cutoff) {
 			logger.Info("skip release due to cooldown",
 				"tag", tag,
-				"published_at", release.GetPublishedAt())
+				"published_at", release.GetPublishedAt(),
+				"cutoff", cutoff)
 			continue
 		}
 		ls, lv, err := compare(latestSemver, latestVersion, tag)

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -32,7 +32,6 @@ type ParamRun struct {
 	Review            *Review
 	Includes          []*regexp.Regexp
 	Excludes          []*regexp.Regexp
-	MinAge            int
 	Now               time.Time
 	Format            string
 	Findings          []Finding

--- a/pkg/di/run.go
+++ b/pkg/di/run.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/fatih/color"
@@ -42,6 +43,12 @@ func Run(ctx context.Context, logger *slogutil.Logger, flags *Flags, secrets *Se
 	if err != nil {
 		return err
 	}
+
+	cfg.EnsureUpdates().MinAge, err = getMinAge(cfg, flags, getEnv)
+	if err != nil {
+		return err
+	}
+
 	cfg.Separator = getSeparator(cfg, flags, getEnv)
 	if err := validateSeparator(cfg.Separator); err != nil {
 		return err
@@ -73,6 +80,29 @@ func getSeparator(cfg *config.Config, flags *Flags, getEnv func(string) string) 
 		return s
 	}
 	return " # "
+}
+
+// getMinAge retrieves the minimum update age set by the user.
+//
+// The --min-age flag takes precedence over everything (so long as it's set, i.e., != 0)
+// if --min-age isn't set (== 0), then env var takes the priority, if the env var is also
+// unset, then the config file value is taken. If minAge isn't set in the config (== 0),
+// then it returns the default value (config.DefaultMinAge).
+func getMinAge(cfg *config.Config, flags *Flags, getEnv func(string) string) (int, error) {
+	if flags.MinAge != 0 {
+		return flags.MinAge, nil
+	}
+	if s := getEnv("PINACT_MIN_AGE"); s != "" {
+		age, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, fmt.Errorf("invalid value: %w", err)
+		}
+		return age, nil
+	}
+	if cfg.Updates != nil && cfg.Updates.MinAge != 0 {
+		return cfg.Updates.MinAge, nil
+	}
+	return config.DefaultMinAge, nil
 }
 
 var separatorPattern = regexp.MustCompile(` +# +(?:tag=)?`)
@@ -134,7 +164,6 @@ func buildParam(flags *Flags, review *run.Review) (*run.ParamRun, error) {
 		Review:            review,
 		Includes:          includes,
 		Excludes:          excludes,
-		MinAge:            flags.MinAge,
 		Now:               time.Now(),
 		Format:            flags.Format,
 	}

--- a/pkg/di/run_internal_test.go
+++ b/pkg/di/run_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/suzuki-shunsuke/pinact/v3/pkg/cli/gflag"
+	"github.com/suzuki-shunsuke/pinact/v3/pkg/config"
 )
 
 func Test_compileRegexps(t *testing.T) {
@@ -114,4 +115,82 @@ func Test_buildParam_invalidRegex(t *testing.T) {
 			t.Error("expected error, got nil")
 		}
 	})
+}
+
+//nolint:funlen
+func Test_getMinAge(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Invalid env var", func(t *testing.T) {
+		_, err := getMinAge(&config.Config{}, &Flags{}, func(string) string {
+			return "not an integer"
+		})
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	data := []struct {
+		name        string
+		cfg         *config.Config
+		flags       *Flags
+		env         string
+		expectedAge int
+	}{
+		{
+			// Config has 'min_age: 14' but user passes '--min-age 7'
+			// => cooldown must be 7 days
+			name:        "flag takes precedence",
+			cfg:         &config.Config{Updates: &config.Updates{MinAge: 14}},
+			flags:       &Flags{MinAge: 7},
+			env:         "",
+			expectedAge: 7,
+		},
+		{
+			name:        "config is used when --min-age flag isn't provided",
+			cfg:         &config.Config{Updates: &config.Updates{MinAge: 14}},
+			flags:       &Flags{},
+			env:         "",
+			expectedAge: 14,
+		},
+		{
+			name:        "env value takes precedence over config",
+			cfg:         &config.Config{Updates: &config.Updates{MinAge: 14}},
+			flags:       &Flags{},
+			env:         "3",
+			expectedAge: 3,
+		},
+		{
+			// When env var + config + flag are provided, then the flag takes precedence
+			name:        "flag takes precedence over env var & over the config",
+			cfg:         &config.Config{Updates: &config.Updates{MinAge: 14}},
+			flags:       &Flags{MinAge: 3},
+			env:         "5",
+			expectedAge: 3,
+		},
+		{
+			// When MinAge isn't set (flags + config + env var), then it should use
+			// the default value
+			name:        "uses the default value when none provided",
+			cfg:         &config.Config{},
+			flags:       &Flags{},
+			env:         "",
+			expectedAge: config.DefaultMinAge,
+		},
+	}
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := getMinAge(d.cfg, d.flags, func(string) string {
+				return d.env
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != d.expectedAge {
+				t.Errorf("wanted %d, got %d", d.expectedAge, got)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This adds a new config file entry for `.pinact.yaml` that allows to customize the default minimum release age. Works as follows:

1. It checks whether the flag `--min-age` was passed (!= 0), if passed, then it returns the value
2. If `--min-age` wasn't provided, it checks whether the env var `PINACT_MIN_AGE` was passed, and if so, it returns it
3. If `--min-age` & env var weren't provided, then it returns the value of the config file (`updates.min_age`) if set
4. Otherwise, it returns the default value

Closes #1507

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: #1507 
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

<!-- Please write the description here -->
