### PR TITLE
feat: add `--branch-to-tag` option to pin branches to latest stable tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,31 @@ INFO[0000] action isn't pinned
   pinact_version=v3.0.0-local program=pinact
 ```
 
+### Pin branches
+
+pinact >= v3.10.0, [#1529](https://github.com/suzuki-shunsuke/pinact/issues/1529)
+
+By default, pinact doesn't pin branches such as `main` or `master`.
+If you want to pin specific branches, you can use the `--branch-to-tag` option.
+
+```sh
+pinact run --branch-to-tag '<regular expression matching branch name>'
+```
+
+The value is evaluated as a regular expression with partial match, just like `--include` / `--exclude`.
+Anchor with `^...$` for an exact match — for short branch names like `main` this is recommended to avoid matching `mainline` etc.
+Versions that don't match any of the supplied regexps continue to error out as before.
+
+The branch is converted to the **latest stable tag** of the action. Pre-releases are used only when no stable tag exists.
+
+`--branch-to-tag` can be specified multiple times.
+
+e.g.
+
+```sh
+pinact run --branch-to-tag '^main$' --branch-to-tag '^release/.*$'
+```
+
 ### -diff, -check, -fix options
 
 The behaviour of `pinact run` command is changed by command line options `-diff`, `-check`, and `-fix`.
@@ -541,10 +566,13 @@ Or pinning version:
 
 ## Q. Why doesn't pinact pin some actions?
 
+> [!TIP]
+> Since v3.10.0, the [`--branch-to-tag`](#pin-branches) option lets you opt-in to pinning specific branches to the latest stable tag of an action.
+
 In some cases pinact doesn't pin versions intentionally, which may confuse you.
 So we describe the reason here.
 
-pinact doesn't pin actions whose versions aren't semver (e.g. `main`, `master`, `release/v1`).
+By default, pinact doesn't pin actions whose versions aren't semver (e.g. `main`, `master`, `release/v1`).
 This is because pinact is designed as a safe tool so that it doesn't change workflows behaviour.
 pinact pins actions but doesn't change SHA of actions at the moment when pinact pins versions.
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ Versions that don't match any of the supplied regexps continue to error out as b
 
 The branch is converted to the **latest stable tag** of the action. Pre-releases are used only when no stable tag exists.
 
+[`--min-age`](#skip-recently-released-versions) is honored: when set, tags released within the cooldown window are skipped.
+
 `--branch-to-tag` can be specified multiple times.
 
 e.g.

--- a/USAGE.md
+++ b/USAGE.md
@@ -11,7 +11,7 @@ USAGE:
    pinact [global options] [command [command options]]
 
 VERSION:
-   3.9.2
+   v3.0.0-local
 
 COMMANDS:
    init        Create .pinact.yaml if it doesn't exist
@@ -37,7 +37,7 @@ NAME:
    pinact init - Create .pinact.yaml if it doesn't exist
 
 USAGE:
-   pinact init
+   pinact init [options]
 
 DESCRIPTION:
    Create .pinact.yaml if it doesn't exist
@@ -53,6 +53,10 @@ DESCRIPTION:
 
 OPTIONS:
    --help, -h  show help
+
+GLOBAL OPTIONS:
+   --log-level string          log level [$PINACT_LOG_LEVEL]
+   --config string, -c string  configuration file path [$PINACT_CONFIG]
 ```
 
 ## pinact run
@@ -63,7 +67,7 @@ NAME:
    pinact run - Pin GitHub Actions versions
 
 USAGE:
-   pinact run [arguments...]
+   pinact run [options] [files ...] 
 
 DESCRIPTION:
    If no argument is passed, pinact searches GitHub Actions workflow files from .github/workflows.
@@ -91,9 +95,14 @@ OPTIONS:
    --pr int                                                     GitHub pull request number (default: 0)
    --include string, -i string [ --include string, -i string ]  A regular expression to fix actions
    --exclude string, -e string [ --exclude string, -e string ]  A regular expression to exclude actions
-   --min-age int, -m int                                        Skip versions released within the specified number of days (requires -u) (default: 0) [$PINACT_MIN_AGE]
+   --branch-to-tag string [ --branch-to-tag string ]            A regular expression to convert non-semver versions (e.g. branch names) to the latest stable tag. Anchor with ^$ for exact match
+   --min-age int, -m int                                        Skip versions released within the specified number of days (requires -u or --branch-to-tag) (default: 0) [$PINACT_MIN_AGE]
    --separator string, --sep string                             Separator between version and tag comment
    --help, -h                                                   show help
+
+GLOBAL OPTIONS:
+   --log-level string          log level [$PINACT_LOG_LEVEL]
+   --config string, -c string  configuration file path [$PINACT_CONFIG]
 ```
 
 ## pinact migrate
@@ -104,7 +113,7 @@ NAME:
    pinact migrate - Migrate .pinact.yaml
 
 USAGE:
-   pinact migrate
+   pinact migrate [options]
 
 DESCRIPTION:
    Migrate the version of .pinact.yaml
@@ -114,6 +123,10 @@ DESCRIPTION:
 
 OPTIONS:
    --help, -h  show help
+
+GLOBAL OPTIONS:
+   --log-level string          log level [$PINACT_LOG_LEVEL]
+   --config string, -c string  configuration file path [$PINACT_CONFIG]
 ```
 
 ## pinact token
@@ -145,7 +158,7 @@ NAME:
    pinact token set - Set GitHub Access token
 
 USAGE:
-   pinact token set
+   pinact token set [options]
 
 DESCRIPTION:
    Set GitHub Access token to keyring.
@@ -153,6 +166,10 @@ DESCRIPTION:
 OPTIONS:
    --stdin     Read GitHub Access token from stdin
    --help, -h  show help
+
+GLOBAL OPTIONS:
+   --log-level string          log level [$PINACT_LOG_LEVEL]
+   --config string, -c string  configuration file path [$PINACT_CONFIG]
 ```
 
 ### token remove
@@ -163,13 +180,17 @@ NAME:
    pinact token remove - Remove GitHub Access token
 
 USAGE:
-   pinact token remove
+   pinact token remove [options]
 
 DESCRIPTION:
    Remove GitHub Access token from keyring.
 
 OPTIONS:
    --help, -h  show help
+
+GLOBAL OPTIONS:
+   --log-level string          log level [$PINACT_LOG_LEVEL]
+   --config string, -c string  configuration file path [$PINACT_CONFIG]
 ```
 
 ## pinact version
@@ -180,11 +201,15 @@ NAME:
    pinact version - Show version
 
 USAGE:
-   pinact version
+   pinact version [options]
 
 OPTIONS:
    --json, -j  Output version in JSON format
    --help, -h  show help
+
+GLOBAL OPTIONS:
+   --log-level string          log level [$PINACT_LOG_LEVEL]
+   --config string, -c string  configuration file path [$PINACT_CONFIG]
 ```
 
 ## pinact completion
@@ -195,7 +220,7 @@ NAME:
    pinact completion - Output shell completion script for bash, zsh, fish, or Powershell
 
 USAGE:
-   pinact completion
+   pinact completion [options]
 
 DESCRIPTION:
    Output shell completion script for bash, zsh, fish, or Powershell.
@@ -216,4 +241,8 @@ DESCRIPTION:
 
 OPTIONS:
    --help, -h  show help
+
+GLOBAL OPTIONS:
+   --log-level string          log level [$PINACT_LOG_LEVEL]
+   --config string, -c string  configuration file path [$PINACT_CONFIG]
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -11,7 +11,7 @@ USAGE:
    pinact [global options] [command [command options]]
 
 VERSION:
-   v3.0.0-local
+   3.9.2
 
 COMMANDS:
    init        Create .pinact.yaml if it doesn't exist
@@ -37,7 +37,7 @@ NAME:
    pinact init - Create .pinact.yaml if it doesn't exist
 
 USAGE:
-   pinact init [options]
+   pinact init
 
 DESCRIPTION:
    Create .pinact.yaml if it doesn't exist
@@ -53,10 +53,6 @@ DESCRIPTION:
 
 OPTIONS:
    --help, -h  show help
-
-GLOBAL OPTIONS:
-   --log-level string          log level [$PINACT_LOG_LEVEL]
-   --config string, -c string  configuration file path [$PINACT_CONFIG]
 ```
 
 ## pinact run
@@ -67,7 +63,7 @@ NAME:
    pinact run - Pin GitHub Actions versions
 
 USAGE:
-   pinact run [options] [files ...] 
+   pinact run [arguments...]
 
 DESCRIPTION:
    If no argument is passed, pinact searches GitHub Actions workflow files from .github/workflows.
@@ -95,14 +91,9 @@ OPTIONS:
    --pr int                                                     GitHub pull request number (default: 0)
    --include string, -i string [ --include string, -i string ]  A regular expression to fix actions
    --exclude string, -e string [ --exclude string, -e string ]  A regular expression to exclude actions
-   --branch-to-tag string [ --branch-to-tag string ]            A regular expression to convert non-semver versions (e.g. branch names) to the latest stable tag. Anchor with ^$ for exact match
-   --min-age int, -m int                                        Skip versions released within the specified number of days (requires -u or --branch-to-tag) (default: 0) [$PINACT_MIN_AGE]
+   --min-age int, -m int                                        Skip versions released within the specified number of days (requires -u) (default: 0) [$PINACT_MIN_AGE]
    --separator string, --sep string                             Separator between version and tag comment
    --help, -h                                                   show help
-
-GLOBAL OPTIONS:
-   --log-level string          log level [$PINACT_LOG_LEVEL]
-   --config string, -c string  configuration file path [$PINACT_CONFIG]
 ```
 
 ## pinact migrate
@@ -113,7 +104,7 @@ NAME:
    pinact migrate - Migrate .pinact.yaml
 
 USAGE:
-   pinact migrate [options]
+   pinact migrate
 
 DESCRIPTION:
    Migrate the version of .pinact.yaml
@@ -123,10 +114,6 @@ DESCRIPTION:
 
 OPTIONS:
    --help, -h  show help
-
-GLOBAL OPTIONS:
-   --log-level string          log level [$PINACT_LOG_LEVEL]
-   --config string, -c string  configuration file path [$PINACT_CONFIG]
 ```
 
 ## pinact token
@@ -158,7 +145,7 @@ NAME:
    pinact token set - Set GitHub Access token
 
 USAGE:
-   pinact token set [options]
+   pinact token set
 
 DESCRIPTION:
    Set GitHub Access token to keyring.
@@ -166,10 +153,6 @@ DESCRIPTION:
 OPTIONS:
    --stdin     Read GitHub Access token from stdin
    --help, -h  show help
-
-GLOBAL OPTIONS:
-   --log-level string          log level [$PINACT_LOG_LEVEL]
-   --config string, -c string  configuration file path [$PINACT_CONFIG]
 ```
 
 ### token remove
@@ -180,17 +163,13 @@ NAME:
    pinact token remove - Remove GitHub Access token
 
 USAGE:
-   pinact token remove [options]
+   pinact token remove
 
 DESCRIPTION:
    Remove GitHub Access token from keyring.
 
 OPTIONS:
    --help, -h  show help
-
-GLOBAL OPTIONS:
-   --log-level string          log level [$PINACT_LOG_LEVEL]
-   --config string, -c string  configuration file path [$PINACT_CONFIG]
 ```
 
 ## pinact version
@@ -201,15 +180,11 @@ NAME:
    pinact version - Show version
 
 USAGE:
-   pinact version [options]
+   pinact version
 
 OPTIONS:
    --json, -j  Output version in JSON format
    --help, -h  show help
-
-GLOBAL OPTIONS:
-   --log-level string          log level [$PINACT_LOG_LEVEL]
-   --config string, -c string  configuration file path [$PINACT_CONFIG]
 ```
 
 ## pinact completion
@@ -220,7 +195,7 @@ NAME:
    pinact completion - Output shell completion script for bash, zsh, fish, or Powershell
 
 USAGE:
-   pinact completion [options]
+   pinact completion
 
 DESCRIPTION:
    Output shell completion script for bash, zsh, fish, or Powershell.
@@ -241,8 +216,4 @@ DESCRIPTION:
 
 OPTIONS:
    --help, -h  show help
-
-GLOBAL OPTIONS:
-   --log-level string          log level [$PINACT_LOG_LEVEL]
-   --config string, -c string  configuration file path [$PINACT_CONFIG]
 ```

--- a/pkg/cli/run/command.go
+++ b/pkg/cli/run/command.go
@@ -140,6 +140,11 @@ $ pinact run .github/actions/foo/action.yaml .github/actions/bar/action.yaml
 				Usage:       "A regular expression to exclude actions",
 				Destination: &flags.Exclude,
 			},
+			&cli.StringSliceFlag{
+				Name:        "branch-to-tag",
+				Usage:       "A regular expression to convert non-semver versions (e.g. branch names) to the latest stable tag. Anchor with ^$ for exact match",
+				Destination: &flags.BranchToTag,
+			},
 			&cli.IntFlag{
 				Name:        "min-age",
 				Aliases:     []string{"m"},

--- a/pkg/cli/run/command.go
+++ b/pkg/cli/run/command.go
@@ -148,7 +148,7 @@ $ pinact run .github/actions/foo/action.yaml .github/actions/bar/action.yaml
 			&cli.IntFlag{
 				Name:        "min-age",
 				Aliases:     []string{"m"},
-				Usage:       "Skip versions released within the specified number of days (requires -u)",
+				Usage:       "Skip versions released within the specified number of days (requires -u or --branch-to-tag)",
 				Destination: &flags.MinAge,
 				Sources:     cli.EnvVars("PINACT_MIN_AGE"),
 				Validator: func(i int) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,17 +59,20 @@ var (
 func validateSchemaVersion(v int) error {
 	switch v {
 	case 0:
-		return slogerr.With(errEmptyConfigVersion, //nolint:wrapcheck
+		return slogerr.With( //nolint:wrapcheck
+			errEmptyConfigVersion,
 			"docs", "https://github.com/suzuki-shunsuke/pinact/blob/main/docs/codes/002.md",
 		)
 	case 2: //nolint:mnd
-		return slogerr.With(errAbandonedConfigVersion, //nolint:wrapcheck
+		return slogerr.With( //nolint:wrapcheck
+			errAbandonedConfigVersion,
 			"docs", "https://github.com/suzuki-shunsuke/pinact/blob/main/docs/codes/003.md",
 		)
 	case 3: //nolint:mnd
 		return nil
 	default:
-		return slogerr.With(errUnsupportedConfigVersion, //nolint:wrapcheck
+		return slogerr.With( //nolint:wrapcheck
+			errUnsupportedConfigVersion,
 			"docs", "https://github.com/suzuki-shunsuke/pinact/blob/main/docs/codes/004.md",
 		)
 	}

--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -30,8 +30,13 @@ type GitService interface {
 // It first tries to get the latest version from releases, and if that fails
 // or returns empty, it falls back to getting the latest version from tags.
 func (c *Controller) getLatestVersion(ctx context.Context, logger *slog.Logger, owner, repo, currentVersion string) (string, error) {
-	isStable := isStableVersion(currentVersion)
+	return c.getLatestVersionWithStable(ctx, logger, owner, repo, isStableVersion(currentVersion))
+}
 
+// getLatestVersionWithStable is the same as getLatestVersion but takes an
+// explicit isStable flag instead of inferring it from currentVersion. Used by
+// branch-to-tag, which has no semver-shaped currentVersion to infer from.
+func (c *Controller) getLatestVersionWithStable(ctx context.Context, logger *slog.Logger, owner, repo string, isStable bool) (string, error) {
 	// Calculate cutoff once for min-age filtering
 	var cutoff time.Time
 	if c.param.MinAge > 0 {

--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -204,6 +204,9 @@ func (c *Controller) parseNoTagLine(ctx context.Context, logger *slog.Logger, ac
 	case FullCommitSHA:
 		return "", nil
 	default:
+		if c.matchBranchToTag(action.Version) {
+			return c.convertBranchToLatestTag(ctx, logger, action)
+		}
 		return "", ErrCantPinned
 	}
 	// @v1, @v1.0.0
@@ -211,6 +214,41 @@ func (c *Controller) parseNoTagLine(ctx context.Context, logger *slog.Logger, ac
 		return c.updateToLatestVersion(ctx, logger, action)
 	}
 	return c.pinCurrentVersion(ctx, logger, action, typ)
+}
+
+// matchBranchToTag reports whether v matches any of the --branch-to-tag regexps.
+func (c *Controller) matchBranchToTag(v string) bool {
+	for _, re := range c.param.BranchToTags {
+		if re.MatchString(v) {
+			return true
+		}
+	}
+	return false
+}
+
+// convertBranchToLatestTag resolves an action's non-semver version (e.g. a
+// branch name) to the latest stable tag of the action's repository and pins
+// the line to its commit SHA. Falls back to including pre-releases only when
+// no stable tag exists.
+func (c *Controller) convertBranchToLatestTag(ctx context.Context, logger *slog.Logger, action *Action) (string, error) {
+	lv, err := c.getLatestVersionWithStable(ctx, logger, action.RepoOwner, action.RepoName, true)
+	if err != nil {
+		return "", fmt.Errorf("get the latest stable version: %w", err)
+	}
+	if lv == "" {
+		lv, err = c.getLatestVersionWithStable(ctx, logger, action.RepoOwner, action.RepoName, false)
+		if err != nil {
+			return "", fmt.Errorf("get the latest version: %w", err)
+		}
+		if lv == "" {
+			return "", ErrCantPinned
+		}
+	}
+	sha, _, err := c.repositoriesService.GetCommitSHA1(ctx, logger, action.RepoOwner, action.RepoName, lv, "")
+	if err != nil {
+		return "", fmt.Errorf("get a reference: %w", err)
+	}
+	return c.patchLine(action, sha, lv), nil
 }
 
 // updateToLatestVersion updates an action to its latest version.
@@ -303,7 +341,8 @@ func (c *Controller) handleCurrentVersionIsLatest(ctx context.Context, logger *s
 // handleUpdateToNewerVersion handles updating to a newer version when available.
 func (c *Controller) handleUpdateToNewerVersion(ctx context.Context, logger *slog.Logger, action *Action, lv string) (string, error) {
 	if !compareVersion(action.VersionComment, lv) {
-		logger.Warn("skip updating because the current version is newer than the new version",
+		logger.Warn(
+			"skip updating because the current version is newer than the new version",
 			"current_version", action.VersionComment,
 			"new_version", lv,
 		)
@@ -444,7 +483,8 @@ func (c *Controller) verify(ctx context.Context, logger *slog.Logger, action *Ac
 	if action.Version == sha {
 		return nil
 	}
-	return slogerr.With(errors.New("action_version must be equal to commit_hash_of_version_annotation"), //nolint:wrapcheck
+	return slogerr.With( //nolint:wrapcheck
+		errors.New("action_version must be equal to commit_hash_of_version_annotation"),
 		"action", action.Name,
 		"action_version", action.Version,
 		"version_annotation", action.VersionComment,

--- a/pkg/controller/run/parse_line_internal_test.go
+++ b/pkg/controller/run/parse_line_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/afero"
@@ -773,15 +774,35 @@ func TestController_parseLine_branchToTag(t *testing.T) { //nolint:funlen
 	tagsNoTag := &github.ListTagsResult{Tags: []*github.RepositoryTag{}, Response: &github.Response{}}
 	releasesNoTag := &github.ListReleasesResult{Releases: []*github.RepositoryRelease{}, Response: &github.Response{}}
 
+	// actions/min-age has v2.0.0 (recent, 1 day ago) and v1.0.0 (older, 30 days ago).
+	// With --min-age 7, v2.0.0 must be skipped and v1.0.0 chosen.
+	now := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	tagsMinAge := &github.ListTagsResult{
+		Tags: []*github.RepositoryTag{
+			{Name: new("v2.0.0"), Commit: &github.Commit{SHA: new("2222222222222222222222222222222222222222")}},
+			{Name: new("v1.0.0"), Commit: &github.Commit{SHA: new("1111111111111111111111111111111111111111")}},
+		},
+		Response: &github.Response{},
+	}
+	releasesMinAge := &github.ListReleasesResult{
+		Releases: []*github.RepositoryRelease{
+			{TagName: new("v2.0.0"), PublishedAt: &github.Timestamp{Time: now.AddDate(0, 0, -1)}},
+			{TagName: new("v1.0.0"), PublishedAt: &github.Timestamp{Time: now.AddDate(0, 0, -30)}},
+		},
+		Response: &github.Response{},
+	}
+
 	commits := map[string]*github.GetCommitSHA1Result{
 		"actions/checkout/v3.5.2":       {SHA: "8e5e7e5ab8b370d6c329ec480221332ada57f0ab"},
 		"actions/no-stable/v1.0.0-beta": {SHA: "bebebebebebebebebebebebebebebebebebebebe"},
+		"actions/min-age/v1.0.0":        {SHA: "1111111111111111111111111111111111111111"},
 	}
 
 	data := []struct {
 		name        string
 		line        string
 		branchToTag []*regexp.Regexp
+		minAge      int
 		exp         string
 		isErr       bool
 	}{
@@ -821,6 +842,13 @@ func TestController_parseLine_branchToTag(t *testing.T) { //nolint:funlen
 			branchToTag: []*regexp.Regexp{regexp.MustCompile(`.*`)},
 			exp:         "  - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2",
 		},
+		{
+			name:        "min-age skips recent stable tag",
+			line:        "  - uses: actions/min-age@main",
+			branchToTag: []*regexp.Regexp{regexp.MustCompile(`^main$`)},
+			minAge:      7,
+			exp:         "  - uses: actions/min-age@1111111111111111111111111111111111111111 # v1.0.0",
+		},
 	}
 	logger := slog.New(slog.DiscardHandler)
 	for _, d := range data {
@@ -832,15 +860,19 @@ func TestController_parseLine_branchToTag(t *testing.T) { //nolint:funlen
 					"actions/checkout/0":  tagsCheckout,
 					"actions/no-stable/0": tagsNoStable,
 					"actions/no-tag/0":    tagsNoTag,
+					"actions/min-age/0":   tagsMinAge,
 				},
 				Releases: map[string]*github.ListReleasesResult{
 					"actions/checkout/0":  releasesCheckout,
 					"actions/no-stable/0": releasesNoStable,
 					"actions/no-tag/0":    releasesNoTag,
+					"actions/min-age/0":   releasesMinAge,
 				},
 				Commits: commits,
 			}, nil, nil, fs, &config.Config{Separator: " # "}, &ParamRun{
 				BranchToTags: d.branchToTag,
+				MinAge:       d.minAge,
+				Now:          now,
 			})
 			line, err := ctrl.parseLine(t.Context(), logger, d.line)
 			if err != nil {

--- a/pkg/controller/run/parse_line_internal_test.go
+++ b/pkg/controller/run/parse_line_internal_test.go
@@ -738,3 +738,123 @@ func TestController_excludeByIncludes(t *testing.T) { //nolint:funlen
 		})
 	}
 }
+
+func TestController_parseLine_branchToTag(t *testing.T) { //nolint:funlen
+	t.Parallel()
+	// Tag/release setup used by all sub-tests: actions/checkout has a stable
+	// v3.5.2 release plus a v4.0.0-rc.1 pre-release. actions/no-stable has only
+	// a pre-release. actions/no-tag has neither.
+	tagsCheckout := &github.ListTagsResult{
+		Tags: []*github.RepositoryTag{
+			{Name: new("v3.5.2"), Commit: &github.Commit{SHA: new("8e5e7e5ab8b370d6c329ec480221332ada57f0ab")}},
+			{Name: new("v4.0.0-rc.1"), Commit: &github.Commit{SHA: new("rcrcrcrcrcrcrcrcrcrcrcrcrcrcrcrcrcrcrcrc")}},
+		},
+		Response: &github.Response{},
+	}
+	releasesCheckout := &github.ListReleasesResult{
+		Releases: []*github.RepositoryRelease{
+			{TagName: new("v3.5.2")},
+			{TagName: new("v4.0.0-rc.1"), Prerelease: new(true)},
+		},
+		Response: &github.Response{},
+	}
+	tagsNoStable := &github.ListTagsResult{
+		Tags: []*github.RepositoryTag{
+			{Name: new("v1.0.0-beta"), Commit: &github.Commit{SHA: new("bebebebebebebebebebebebebebebebebebebebe")}},
+		},
+		Response: &github.Response{},
+	}
+	releasesNoStable := &github.ListReleasesResult{
+		Releases: []*github.RepositoryRelease{
+			{TagName: new("v1.0.0-beta"), Prerelease: new(true)},
+		},
+		Response: &github.Response{},
+	}
+	tagsNoTag := &github.ListTagsResult{Tags: []*github.RepositoryTag{}, Response: &github.Response{}}
+	releasesNoTag := &github.ListReleasesResult{Releases: []*github.RepositoryRelease{}, Response: &github.Response{}}
+
+	commits := map[string]*github.GetCommitSHA1Result{
+		"actions/checkout/v3.5.2":       {SHA: "8e5e7e5ab8b370d6c329ec480221332ada57f0ab"},
+		"actions/no-stable/v1.0.0-beta": {SHA: "bebebebebebebebebebebebebebebebebebebebe"},
+	}
+
+	data := []struct {
+		name        string
+		line        string
+		branchToTag []*regexp.Regexp
+		exp         string
+		isErr       bool
+	}{
+		{
+			name:        "main matches and is converted to latest stable tag",
+			line:        "  - uses: actions/checkout@main",
+			branchToTag: []*regexp.Regexp{regexp.MustCompile(`^main$`)},
+			exp:         "  - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2",
+		},
+		{
+			name:        "regex unmatched still errors",
+			line:        "  - uses: actions/checkout@main",
+			branchToTag: []*regexp.Regexp{regexp.MustCompile(`^master$`)},
+			isErr:       true,
+		},
+		{
+			name:        "no branch-to-tag configured still errors",
+			line:        "  - uses: actions/checkout@main",
+			branchToTag: nil,
+			isErr:       true,
+		},
+		{
+			name:        "falls back to pre-release when no stable tag exists",
+			line:        "  - uses: actions/no-stable@develop",
+			branchToTag: []*regexp.Regexp{regexp.MustCompile(`^develop$`)},
+			exp:         "  - uses: actions/no-stable@bebebebebebebebebebebebebebebebebebebebe # v1.0.0-beta",
+		},
+		{
+			name:        "errors when action has no tag at all",
+			line:        "  - uses: actions/no-tag@main",
+			branchToTag: []*regexp.Regexp{regexp.MustCompile(`^main$`)},
+			isErr:       true,
+		},
+		{
+			name:        "semver line is unaffected by branch-to-tag",
+			line:        "  - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3",
+			branchToTag: []*regexp.Regexp{regexp.MustCompile(`.*`)},
+			exp:         "  - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2",
+		},
+	}
+	logger := slog.New(slog.DiscardHandler)
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			fs := afero.NewMemMapFs()
+			ctrl := New(&github.RepositoriesServiceImpl{
+				Tags: map[string]*github.ListTagsResult{
+					"actions/checkout/0":  tagsCheckout,
+					"actions/no-stable/0": tagsNoStable,
+					"actions/no-tag/0":    tagsNoTag,
+				},
+				Releases: map[string]*github.ListReleasesResult{
+					"actions/checkout/0":  releasesCheckout,
+					"actions/no-stable/0": releasesNoStable,
+					"actions/no-tag/0":    releasesNoTag,
+				},
+				Commits: commits,
+			}, nil, nil, fs, &config.Config{Separator: " # "}, &ParamRun{
+				BranchToTags: d.branchToTag,
+			})
+			line, err := ctrl.parseLine(t.Context(), logger, d.line)
+			if err != nil {
+				if d.isErr {
+					return
+				}
+				t.Fatal(err)
+			}
+			if d.isErr {
+				t.Fatalf("expected error, got line %q", line)
+			}
+			if line != d.exp {
+				t.Fatalf("wanted %s, got %s", d.exp, line)
+			}
+		})
+	}
+}

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -32,6 +32,7 @@ type ParamRun struct {
 	Review            *Review
 	Includes          []*regexp.Regexp
 	Excludes          []*regexp.Regexp
+	BranchToTags      []*regexp.Regexp
 	MinAge            int
 	Now               time.Time
 	Format            string
@@ -219,7 +220,8 @@ func (c *Controller) handleParseLineError(ctx context.Context, logger *slog.Logg
 		if code == http.StatusUnprocessableEntity {
 			level = slog.LevelWarn
 		}
-		slogerr.WithError(logger, err).Log(ctx, level, "create a review comment",
+		slogerr.WithError(logger, err).Log(
+			ctx, level, "create a review comment",
 			"review_repo_owner", c.param.Review.RepoOwner,
 			"review_repo_name", c.param.Review.RepoName,
 			"review_pr_number", c.param.Review.PullRequest,
@@ -260,7 +262,8 @@ func (c *Controller) tryCreateReview(ctx context.Context, logger *slog.Logger, l
 		if code == http.StatusUnprocessableEntity {
 			level = slog.LevelWarn
 		}
-		slogerr.WithError(logger, err).Log(ctx, level, "create a review comment",
+		slogerr.WithError(logger, err).Log(
+			ctx, level, "create a review comment",
 			"review_repo_owner", c.param.Review.RepoOwner,
 			"review_repo_name", c.param.Review.RepoName,
 			"review_pr_number", c.param.Review.PullRequest,

--- a/pkg/di/flag.go
+++ b/pkg/di/flag.go
@@ -34,12 +34,13 @@ type Flags struct {
 
 	CWD string
 
-	FixCount int
-	PR       int
-	MinAge   int
-	Include  []string
-	Exclude  []string
-	Args     []string
+	FixCount    int
+	PR          int
+	MinAge      int
+	Include     []string
+	Exclude     []string
+	BranchToTag []string
+	Args        []string
 }
 
 const defaultGitHubAPIURL = "https://api.github.com"

--- a/pkg/di/run.go
+++ b/pkg/di/run.go
@@ -119,6 +119,10 @@ func buildParam(flags *Flags, review *run.Review) (*run.ParamRun, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse exclude: %w", err)
 	}
+	branchToTags, err := compileRegexps(flags.BranchToTag)
+	if err != nil {
+		return nil, fmt.Errorf("parse branch-to-tag: %w", err)
+	}
 	param := &run.ParamRun{
 		WorkflowFilePaths: flags.Args,
 		ConfigFilePath:    flags.Config,
@@ -134,6 +138,7 @@ func buildParam(flags *Flags, review *run.Review) (*run.ParamRun, error) {
 		Review:            review,
 		Includes:          includes,
 		Excludes:          excludes,
+		BranchToTags:      branchToTags,
 		MinAge:            flags.MinAge,
 		Now:               time.Now(),
 		Format:            flags.Format,


### PR DESCRIPTION
Closes #1529.

## Summary

Adds a new `--branch-to-tag` option to `pinact run` that lets users opt-in to pinning workflow lines whose version is not a semver and not a full commit SHA (e.g. branch refs like `@main`). Until now these lines errored out with `ErrCantPinned`; with this option they are resolved to the latest **stable** tag of the action and pinned to its commit SHA.

```sh
pinact run --branch-to-tag '^main$' --branch-to-tag '^master$'
pinact run --branch-to-tag '^release/'
```

The flag is repeatable and each value is evaluated as a regex (same shape as the existing `--include` / `--exclude`). Anchor with `^...$` for exact match. Lines whose version does not match any of the supplied regexps continue to error as before, so the feature is strict opt-in and won't silently convert typos or short SHAs.

## Changes

### CLI surface — `pkg/cli/run/command.go`, `pkg/di/flag.go`

- New `cli.StringSliceFlag` named `branch-to-tag` wired to `Flags.BranchToTag []string`.
- Follows the same plumbing as `--include` / `--exclude`.

### DI — `pkg/di/run.go`

- `buildParam` now compiles `flags.BranchToTag` (`[]string`) into `[]*regexp.Regexp` via the existing `compileRegexps` helper and passes it to `ParamRun.BranchToTags`.
- A compile error returns `parse branch-to-tag: ...` so users get clear feedback on invalid regex.

### Controller param — `pkg/controller/run/run.go`

- Adds `BranchToTags []*regexp.Regexp` to `ParamRun`, matching the singular/plural convention already used by `Includes` / `Excludes`.

### Core logic — `pkg/controller/run/parse_line.go`

- `parseNoTagLine`'s `default` arm (the `Other` `VersionType`, which covers branch names and any other non-semver / non-full-SHA strings) now consults the new regex list. On match, control hands off to `convertBranchToLatestTag`; otherwise behavior is unchanged (`ErrCantPinned`).
- New helper `matchBranchToTag(version string) bool` iterates `c.param.BranchToTags`.
- New method `convertBranchToLatestTag`:
  1. Calls `getLatestVersionWithStable(..., isStable=true)` to prefer stable tags.
  2. If the result is empty (no stable release/tag exists), falls back to `getLatestVersionWithStable(..., isStable=false)` so pre-releases become eligible.
  3. Returns `ErrCantPinned` if the action has no tag at all.
  4. Resolves the chosen tag to a SHA via `repositoriesService.GetCommitSHA1` and patches the line with `c.patchLine(action, sha, tag)`.

### Stability override — `pkg/controller/run/github.go`

- Extracted the body of `getLatestVersion` into a new `getLatestVersionWithStable(ctx, logger, owner, repo, isStable bool) (string, error)`.
- The existing `getLatestVersion(..., currentVersion string)` is now a thin wrapper that derives `isStable` from `currentVersion` via `isStableVersion`. Behavior for existing callers is unchanged.
- `convertBranchToLatestTag` uses the new method because the input version (e.g. `main`) doesn't parse as semver and `isStableVersion("main")` would otherwise return `false`, including pre-releases unintentionally.

### Tests — `pkg/controller/run/parse_line_internal_test.go`

- New `TestController_parseLine_branchToTag` with six subtests, each driven by a different `BranchToTags` regex slice against a shared mock `RepositoriesServiceImpl`:
  - **`main matches and is converted to latest stable tag`** — happy path; `@main` becomes `@<v3.5.2 SHA> # v3.5.2`, ignoring `v4.0.0-rc.1`.
  - **`regex unmatched still errors`** — `--branch-to-tag '^master$'` against `@main` returns `ErrCantPinned`.
  - **`no branch-to-tag configured still errors`** — preserves existing behavior when the option is empty.
  - **`falls back to pre-release when no stable tag exists`** — action with only `v1.0.0-beta` resolves to that pre-release.
  - **`errors when action has no tag at all`** — empty tag/release lists produce `ErrCantPinned`.
  - **`semver line is unaffected by branch-to-tag`** — confirms that lines with a semver `VersionComment` go through the existing path even when `BranchToTags` is `.*`.

### Drive-by lint fix — `pkg/config/config.go`

- The repo's formatter (`gofumpt`, via `cmdx fmt`) splits `slogerr.With(arg, //nolint:wrapcheck` onto multiple lines, which puts the `//nolint:wrapcheck` directive on a different line than the `slogerr.With(` call that triggers the `wrapcheck` warning. The directive was therefore inert and `golangci-lint` failed with `wrapcheck` + `nolintlint` after `cmdx fmt` ran.
- Moved the `//nolint:wrapcheck` directives onto the `slogerr.With(` line itself in all three branches of `validateSchemaVersion`. The same fix is applied to the analogous spot in `pkg/controller/run/parse_line.go` (the `verify` helper).

## Verification

- `cmdx v` (`go vet ./...`) — passes
- `cmdx t` (`go test ./... -race -covermode=atomic`) — passes, including the six new `TestController_parseLine_branchToTag` subtests
- `cmdx l` (`golangci-lint`) — `wrapcheck` / `nolintlint` regressions caused by the formatter are resolved; remaining `staticcheck SA5011` warnings are pre-existing in test files not touched by this PR (`pkg/controller/run/log_internal_test.go`, `pkg/di/flag_test.go`, `pkg/di/review_internal_test.go`).

## Design decisions (recap from #1529)

- **Match mode is regex**, not glob or exact match. Reuses the existing `--include` / `--exclude` machinery and avoids glob's tool-dependent `/`-handling. Use `^foo$` for exact match.
- **Repeatable flag**, not a single bool. Whitelisting the branches the user knows about avoids silently converting typos and short SHAs in the `Other` bucket.
- **Stable-first, pre-release fallback.** Pinning `main` to `v2.0.0-beta.1` would be surprising. Pre-releases only kick in when stable tags are absent.
- **No `.pinact.yaml` support** in this PR — CLI flag only. A config-file entry can be added later if demand emerges.
- **No branch-pattern → tag-pattern mapping.** Even with `--branch-to-tag '^release/'`, every match is pinned to the action's overall latest stable tag; we don't try to align the branch's implied version with the tag's major.
