### PR TITLE
fix: pin uses lines with multiple spaces after the YAML list dash

### DIFF
--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	usesPattern          = regexp.MustCompile(`^( *(?:- )?['"]?uses['"]? *: +)(['"]?)(.*?)@([^ '"]+)['"]?(?:( +# +(?:tag=)?)(v?\d+[^ ]*)(.*))?`)
+	usesPattern          = regexp.MustCompile(`^( *(?:- +)?['"]?uses['"]? *: +)(['"]?)(.*?)@([^ '"]+)['"]?(?:( +# +(?:tag=)?)(v?\d+[^ ]*)(.*))?`)
 	fullCommitSHAPattern = regexp.MustCompile(`\b[0-9a-f]{40}\b`)
 	semverPattern        = regexp.MustCompile(`^v?\d+\.\d+\.\d+[^ ]*$`)
 	shortTagPattern      = regexp.MustCompile(`^v?\d+(\.\d+)?$`)

--- a/pkg/controller/run/parse_line_internal_test.go
+++ b/pkg/controller/run/parse_line_internal_test.go
@@ -101,6 +101,17 @@ func Test_parseAction(t *testing.T) { //nolint:funlen
 				Quote:                   "",
 			},
 		},
+		{
+			name: "multi-space after dash",
+			line: "    -   uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3",
+			exp: &Action{
+				Uses:                    "    -   uses: ",
+				Name:                    "actions/checkout",
+				Version:                 "8e5e7e5ab8b370d6c329ec480221332ada57f0ab",
+				VersionCommentSeparator: " # ",
+				VersionComment:          "v3",
+			},
+		},
 	}
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
@@ -149,6 +160,11 @@ func TestController_parseLine(t *testing.T) { //nolint:funlen
 			name: "checkout v2 (single quote)",
 			line: `  "uses": 'actions/checkout@v2'`,
 			exp:  `  "uses": 'actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5' # v2.7.0`,
+		},
+		{
+			name: "multi-space after dash",
+			line: "      -   uses: actions/checkout@v3",
+			exp:  "      -   uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2",
 		},
 	}
 	logger := slog.New(slog.DiscardHandler)

--- a/testdata/foo.yaml
+++ b/testdata/foo.yaml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  #  v3
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  #  tag=v3
       - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247
+      -   uses: actions/checkout@v2
       - uses: actions/checkout@v2
       - uses: actions/cache@v3.3.1
       - uses: actions/setup-java@v3

--- a/testdata/foo_after.yaml
+++ b/testdata/foo_after.yaml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  #  v3.5.3
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  #  tag=v3.5.3
       - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247
+      -   uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
       - uses: actions/setup-java@v3

--- a/testdata/foo_exclude_after.yaml
+++ b/testdata/foo_exclude_after.yaml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  #  v3
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  #  tag=v3
       - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247
+      -   uses: actions/checkout@v2
       - uses: actions/checkout@v2
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
       - uses: actions/setup-java@v3

--- a/testdata/foo_include_after.yaml
+++ b/testdata/foo_include_after.yaml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  #  v3.5.3
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  #  tag=v3.5.3
       - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247
+      -   uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - uses: actions/cache@v3.3.1
       - uses: actions/setup-java@v3


### PR DESCRIPTION
## Summary

Fixes #1534.

`pinact` silently skipped `uses:` lines when more than one space sat between the YAML block-sequence indicator `-` and the `uses:` key (e.g. `-   uses:`). The form is valid YAML — the spec allows any positive number of spaces after `-` — and it is common in workflow files using 4-space indentation. Since `pinact run` exits 0 with no warning when this happens, users had no signal that references remained unpinned (the issue reporter found 15 silently-skipped references across 4 workflow files).

## Root cause

`pkg/controller/run/parse_line.go` defines a single regex that gates the entire line-parser:

```go
usesPattern = regexp.MustCompile(`^( *(?:- )?['"]?uses['"]? *: +)...`)
```

The sub-expression `(?:- )?` matches the literal `- ` — dash followed by **exactly** one space. Anything wider falls through `parseAction` returning `nil`, which `parseLine` logs as `unmatch` and ignores.

## Change

Replace `(?:- )?` with `(?:- +)?` so one or more spaces after the dash are accepted. The captured group `matches[1]` still holds the exact original prefix verbatim, so `patchLine` reconstructs the line preserving the user's original indentation (including the wide gap after the dash).

## Diff overview

- `pkg/controller/run/parse_line.go` — single-character regex change (`- ` → `- +`).
- `pkg/controller/run/parse_line_internal_test.go` — adds a `multi-space after dash` case to both `Test_parseAction` (asserts the captured `Uses` field preserves the wide gap) and `TestController_parseLine` (asserts a `-   uses: actions/checkout@v3` line is rewritten to its pinned SHA form with the three spaces preserved).
- `testdata/foo.yaml` and its three companion `*_after.yaml` files (`foo_after.yaml`, `foo_include_after.yaml`, `foo_exclude_after.yaml`) — adds a `-   uses: actions/checkout@v2` step. The integration-test workflow (`.github/workflows/workflow_call_integration_test.yaml`) runs `pinact run` on `foo.yaml` and diffs against each `_after` variant, so all four had to stay in sync:
  - `foo_after.yaml` and `foo_include_after.yaml` (checkout matches `-i`): pinned to `ee0669bd... # v2.7.0`, three spaces preserved.
  - `foo_exclude_after.yaml` (checkout matches `-e`): unchanged from input.

## Test plan

- [x] `cmdx v` (go vet)
- [x] `cmdx t` (full test suite, including the two new unit cases)
- [x] Integration smoke test for all three modes:
  - `pinact run testdata/foo.yaml` → diff against `testdata/foo_after.yaml` is empty
  - `pinact run -i "^actions/checkout$" testdata/foo.yaml` → diff against `testdata/foo_include_after.yaml` is empty
  - `pinact run -e "^actions/checkout$" testdata/foo.yaml` → diff against `testdata/foo_exclude_after.yaml` is empty
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)