### PR TITLE
feat(config): PINACT_GLOBAL_CONFIG env var overrides the global config path

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -58,16 +58,17 @@ Or pinning version:
 
 pinact supports a global configuration file for user-wide defaults.
 
-Global Configuration File Paths:
+Global Configuration File Paths (highest precedence first):
 
-1. Linux, macOS:
+1. `$PINACT_GLOBAL_CONFIG` if set (any absolute or relative path; no `~` or `$VAR` expansion is performed)
+2. Linux, macOS:
     1. `$XDG_CONFIG_HOME/pinact/pinact.yaml` if `$XDG_CONFIG_HOME` is set
     2. `~/.config/pinact/pinact.yaml`
-2. Windows:
+3. Windows:
     1. `%APPDATA%\pinact\pinact.yaml`
 
 A global configuration file is ignored if a local configuration file is found.
-`pinact init -g` creates a global configuration file if it doesn't exist.
+`pinact init -g` creates a global configuration file if it doesn't exist (and honors `$PINACT_GLOBAL_CONFIG` for the target path).
 
 ```sh
 pinact init -g

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -337,18 +337,26 @@ func GlobalConfigPath() string {
 	return resolveGlobalConfigPath(runtime.GOOS, os.Getenv, getHomeDir())
 }
 
-// resolveGlobalConfigPath returns the absolute path of the global config file
-// for the current platform, or "" if it cannot be resolved.
+// resolveGlobalConfigPath returns the path of the pinact global config file,
+// or "" if it cannot be resolved. Precedence:
 //
-// Linux / macOS: $XDG_CONFIG_HOME/pinact/pinact.yaml when XDG_CONFIG_HOME is
-// set, otherwise <home>/.config/pinact/pinact.yaml. macOS deliberately uses
-// the XDG layout rather than ~/Library/Application Support to avoid the
-// space in the path and to match what most developer tooling expects.
+//  1. PINACT_GLOBAL_CONFIG env var (used verbatim; absolute or relative).
+//  2. Platform-native location:
+//     - Linux / macOS: $XDG_CONFIG_HOME/pinact/pinact.yaml when
+//     XDG_CONFIG_HOME is set, otherwise <home>/.config/pinact/pinact.yaml.
+//     macOS deliberately uses the XDG layout rather than
+//     ~/Library/Application Support to avoid the space in the path and to
+//     match what most developer tooling expects.
+//     - Windows: %APPDATA%\pinact\pinact.yaml. APPDATA is the Roaming
+//     AppData folder, the standard location for user-specific config that
+//     should follow the user across machines.
 //
-// Windows: %APPDATA%\pinact\pinact.yaml. APPDATA is the Roaming AppData
-// folder, the standard location for user-specific config that should follow
-// the user across machines.
+// PINACT_GLOBAL_CONFIG is not subject to ~/$VAR expansion; callers can use
+// shell expansion at the point of invocation if they need it.
 func resolveGlobalConfigPath(goos string, getEnv func(string) string, homeDir string) string {
+	if p := getEnv("PINACT_GLOBAL_CONFIG"); p != "" {
+		return p
+	}
 	const windows = "windows"
 	if goos == windows {
 		appData := getEnv("APPDATA")

--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -225,6 +225,34 @@ func Test_resolveGlobalConfigPath(t *testing.T) { //nolint:funlen
 			homeDir: "",
 			want:    "",
 		},
+		{
+			name:    "PINACT_GLOBAL_CONFIG wins over linux XDG path",
+			goos:    "linux",
+			env:     map[string]string{"PINACT_GLOBAL_CONFIG": "/tmp/custom.yaml", "XDG_CONFIG_HOME": "/xdg"},
+			homeDir: "/home/user",
+			want:    "/tmp/custom.yaml",
+		},
+		{
+			name:    "PINACT_GLOBAL_CONFIG wins over macOS default",
+			goos:    "darwin",
+			env:     map[string]string{"PINACT_GLOBAL_CONFIG": "/Users/user/dotfiles/pinact.yaml"},
+			homeDir: "/Users/user",
+			want:    "/Users/user/dotfiles/pinact.yaml",
+		},
+		{
+			name:    "PINACT_GLOBAL_CONFIG wins over Windows APPDATA",
+			goos:    "windows",
+			env:     map[string]string{"PINACT_GLOBAL_CONFIG": `D:\config\pinact.yaml`, "APPDATA": `C:\Users\user\AppData\Roaming`},
+			homeDir: `C:\Users\user`,
+			want:    `D:\config\pinact.yaml`,
+		},
+		{
+			name:    "PINACT_GLOBAL_CONFIG empty string falls back to OS default",
+			goos:    "linux",
+			env:     map[string]string{"PINACT_GLOBAL_CONFIG": "", "XDG_CONFIG_HOME": "/xdg"},
+			homeDir: "/home/user",
+			want:    "/xdg/pinact/pinact.yaml",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- New `PINACT_GLOBAL_CONFIG` env var: when set, its value is used as the global config path directly, overriding the platform-native default (`~/.config/pinact/pinact.yaml` on Unix / `%APPDATA%\pinact\pinact.yaml` on Windows).
- The env var value is used verbatim; no `~` or `$VAR` expansion is performed (callers can expand in the shell when needed).
- Both the project-config-not-found fallback (`getConfigPath`) and `pinact init -g` pick up the override automatically through `config.GlobalConfigPath()`.

Motivation:

- Keep the file under `~/dotfiles/pinact.yaml` without symlinking.
- Swap between configs per shell (work vs personal, fixture vs production).
- Point pinact at a CI fixture without matching the runner's home layout.

## Test plan

- [x] `cmdx t` — new env-var cases pass in `Test_resolveGlobalConfigPath` (Linux / macOS / Windows + empty-string fallback).
- [x] `golangci-lint run` clean.
- [x] End-to-end:
  - `PINACT_GLOBAL_CONFIG=/tmp/g.yaml pinact run -verify-min-age action.yaml` reads `/tmp/g.yaml` for the audit threshold.
  - `PINACT_GLOBAL_CONFIG=/tmp/g.yaml pinact init -g` creates `/tmp/g.yaml` and prints the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)