### PR TITLE
feat(run): add --diff-file to process only PR-changed lines

### DIFF
--- a/.github/workflows/workflow_call_integration_test.yaml
+++ b/.github/workflows/workflow_call_integration_test.yaml
@@ -4,7 +4,7 @@ on: workflow_call
 
 jobs:
   integration-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions: {}
     timeout-minutes: 20
     steps:
@@ -76,6 +76,14 @@ jobs:
           GITHUB_TOKEN: ${{github.token}}
       - run: diff .pinact.yaml pinact.yaml.after
         working-directory: testdata/migrate
+
+      # Test --diff-file
+      # 1. actions included in diff are pinned
+      # 1. actions not included in diff aren't pinned
+      - run: pinact run -diff-file testdata/diff-file/diff.txt testdata/diff-file/action.yaml
+        env:
+          GITHUB_TOKEN: ${{github.token}}
+      - run: diff testdata/diff-file/action.yaml testdata/diff-file/action_after.yaml
 
       - run: pinact run -u
         env:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ pinact run
 1. [Include and exclude specific actions](#include-and-exclude-specific-actions)
 1. [Generate SARIF](#sarif). This is useful to create reviews using [reviewdog](#reviewdog)
 1. [Read GitHub access token via keyrings or ghtkn](#github-access-token)
+1. [Pin only changed lines](#pin-only-changed-lines)
 1. [Support GitHub Enterprise Server](docs/ghes.md)
 1. [GitHub Action](https://github.com/suzuki-shunsuke/pinact-action)
 
@@ -238,6 +239,51 @@ pinact run -format sarif |
   with:
     sarif_file: sarif.json
     category: pinact
+```
+
+### Pin Only Changed Lines
+
+pinact >= v4.0.0
+
+pinact supports pinning only changed lines using the `-diff-file` option.
+This is useful to introduce pinact gradually.
+
+```sh
+pinact run -diff-file diff.txt 
+```
+
+diff.txt must be the unified diff format.
+
+[example](testdata/diff-file/diff.txt)
+
+```diff
+diff --git a/testdata/diff-file/action.yaml b/testdata/diff-file/action.yaml
+index 0000001..0000002 100644
+--- a/testdata/diff-file/action.yaml
++++ b/testdata/diff-file/action.yaml
+@@ -7,5 +7,5 @@ jobs:
+     permissions: {}
+     steps:
+       - uses: actions/checkout@v3.6.0
+-      - uses: actions/setup-go@v3.5.0
++      - uses: actions/setup-go@v4.0.0
+       - uses: actions/cache@v3.3.1
+```
+
+`-diff-file -` means reading from stdin:
+
+```sh
+cat diff.txt | pinact run -diff-file -
+```
+
+You can generate a diff file via GitHub Actions using [pr-unified-diff-action](https://github.com/suzuki-shunsuke/pr-unified-diff-action).
+
+```yaml
+- uses: suzuki-shunsuke/pr-unified-diff-action@c932c1df5f577028d8ca05d2d3c0c059072d8821 # v0.0.1
+  id: diff
+- run: pinact run -diff-file "$DIFF_FILE"
+  env:
+    DIFF_FILE: ${{ steps.diff.outputs.diff_path }}
 ```
 
 ## GitHub Access token

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v86 v86.0.0
 	github.com/hashicorp/go-version v1.9.0
+	github.com/sourcegraph/go-diff v0.8.0
 	github.com/spf13/afero v1.15.0
 	github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0
 	github.com/suzuki-shunsuke/ghtkn-go-sdk v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/sourcegraph/go-diff v0.8.0 h1:ipIyu4cTsLbIrln4l0qtHA3r0a7gyK4ntKjtQytHhvY=
+github.com/sourcegraph/go-diff v0.8.0/go.mod h1:hWlcO7Al+UZStZAP8rBumHpCK5ZHQ5BXsMls8p4+F5E=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=

--- a/pkg/cli/run/command.go
+++ b/pkg/cli/run/command.go
@@ -174,6 +174,11 @@ $ pinact run .github/actions/foo/action.yaml .github/actions/bar/action.yaml
 				Usage:       "Separator between version and tag comment",
 				Destination: &flags.Separator,
 			},
+			&cli.StringFlag{
+				Name:        "diff-file",
+				Usage:       "Path to a unified diff. Only the `+` lines of the diff are processed (use `-` to read the diff from stdin). Useful in PR CI to limit pinact to lines changed by the PR",
+				Destination: &flags.DiffFile,
+			},
 		},
 		Arguments: []cli.Argument{
 			&cli.StringArgs{

--- a/pkg/controller/run/diff_filter.go
+++ b/pkg/controller/run/diff_filter.go
@@ -1,0 +1,122 @@
+package run
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/sourcegraph/go-diff/diff"
+)
+
+// DiffLine represents a single added line (post-image) extracted from a
+// unified diff. Number is the 1-based line number in the new file.
+type DiffLine struct {
+	Number  int
+	Content string
+}
+
+// DiffFilter holds the set of added lines per file path, parsed from a
+// unified diff. When set on ParamRun, pinact processes only these lines.
+type DiffFilter struct {
+	files map[string][]DiffLine
+}
+
+// ParseDiff reads a unified diff from r and returns the set of `+` lines
+// per file (keyed by post-image path with `a/` / `b/` prefixes stripped).
+//
+// Files renamed to /dev/null (deletions) are excluded. Renames are tracked
+// under the new path. A file with no `+` lines (rename-only, mode change)
+// is excluded.
+func ParseDiff(r io.Reader) (*DiffFilter, error) {
+	fileDiffs, err := diff.NewMultiFileDiffReader(r).ReadAllFiles()
+	if err != nil {
+		return nil, fmt.Errorf("parse unified diff: %w", err)
+	}
+	files := make(map[string][]DiffLine)
+	for _, fd := range fileDiffs {
+		path := newPath(fd)
+		if path == "" {
+			continue
+		}
+		lines := addedLines(fd)
+		if len(lines) == 0 {
+			continue
+		}
+		files[path] = append(files[path], lines...)
+	}
+	return &DiffFilter{files: files}, nil
+}
+
+// Files returns the set of file paths covered by this filter.
+func (f *DiffFilter) Files() []string {
+	paths := make([]string, 0, len(f.files))
+	for p := range f.files {
+		paths = append(paths, p)
+	}
+	return paths
+}
+
+// Lines returns the `+` lines recorded for the given path, or nil if the
+// path is not in the filter.
+func (f *DiffFilter) Lines(path string) []DiffLine {
+	return f.files[path]
+}
+
+// Has reports whether the filter contains any `+` lines for path.
+func (f *DiffFilter) Has(path string) bool {
+	_, ok := f.files[path]
+	return ok
+}
+
+// newPath returns the post-image path for a FileDiff with `a/` / `b/`
+// prefixes stripped. Returns "" for deleted files (NewName == /dev/null).
+func newPath(fd *diff.FileDiff) string {
+	if fd.NewName == "" || fd.NewName == "/dev/null" {
+		return ""
+	}
+	return stripDiffPathPrefix(fd.NewName)
+}
+
+// stripDiffPathPrefix removes a leading `a/` or `b/` from a unified diff
+// path. Other prefixes are returned as-is.
+func stripDiffPathPrefix(p string) string {
+	switch {
+	case strings.HasPrefix(p, "a/"):
+		return p[2:]
+	case strings.HasPrefix(p, "b/"):
+		return p[2:]
+	}
+	return p
+}
+
+// addedLines walks every hunk in fd and returns the post-image line numbers
+// and contents of `+` lines. New-file line numbers start at hunk.NewStartLine
+// and advance for `+` and ` ` (context) prefixes; `-` lines do not advance
+// the counter, and `\` (no-newline marker) lines are skipped.
+func addedLines(fd *diff.FileDiff) []DiffLine {
+	var out []DiffLine
+	for _, h := range fd.Hunks {
+		newLine := int(h.NewStartLine)
+		for raw := range bytes.SplitSeq(h.Body, []byte{'\n'}) {
+			if len(raw) == 0 {
+				continue
+			}
+			switch raw[0] {
+			case '+':
+				out = append(out, DiffLine{
+					Number:  newLine,
+					Content: string(raw[1:]),
+				})
+				newLine++
+			case ' ':
+				newLine++
+			case '-':
+				// removed line: new-file counter does not advance
+			case '\\':
+				// "\ No newline at end of file" marker: skip
+			}
+		}
+	}
+	return out
+}

--- a/pkg/controller/run/diff_filter_internal_test.go
+++ b/pkg/controller/run/diff_filter_internal_test.go
@@ -1,0 +1,216 @@
+package run
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseDiff(t *testing.T) { //nolint:funlen
+	t.Parallel()
+	tests := []struct {
+		name string
+		diff string
+		want map[string][]DiffLine
+	}{
+		{
+			name: "single hunk with one + line",
+			diff: `diff --git a/.github/workflows/wc-test.yaml b/.github/workflows/wc-test.yaml
+index 1f703973..cc980f16 100644
+--- a/.github/workflows/wc-test.yaml
++++ b/.github/workflows/wc-test.yaml
+@@ -12,7 +12,7 @@ jobs:
+         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+         with:
+           persist-credentials: false
+-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
++      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+         with:
+           go-version-file: go.mod
+           cache: true
+`,
+			want: map[string][]DiffLine{
+				".github/workflows/wc-test.yaml": {
+					{Number: 15, Content: "      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0"},
+				},
+			},
+		},
+		{
+			name: "new file: every body line is +",
+			diff: `diff --git a/.github/workflows/new.yaml b/.github/workflows/new.yaml
+new file mode 100644
+index 0000000..abcdef0
+--- /dev/null
++++ b/.github/workflows/new.yaml
+@@ -0,0 +1,3 @@
++name: new
++on: push
++jobs: {}
+`,
+			want: map[string][]DiffLine{
+				".github/workflows/new.yaml": {
+					{Number: 1, Content: "name: new"},
+					{Number: 2, Content: "on: push"},
+					{Number: 3, Content: "jobs: {}"},
+				},
+			},
+		},
+		{
+			name: "deleted file is excluded",
+			diff: `diff --git a/.github/workflows/old.yaml b/.github/workflows/old.yaml
+deleted file mode 100644
+index abcdef0..0000000
+--- a/.github/workflows/old.yaml
++++ /dev/null
+@@ -1,3 +0,0 @@
+-name: old
+-on: push
+-jobs: {}
+`,
+			want: map[string][]DiffLine{},
+		},
+		{
+			name: "rename + edit uses new path",
+			diff: `diff --git a/.github/workflows/old.yaml b/.github/workflows/new.yaml
+similarity index 80%
+rename from .github/workflows/old.yaml
+rename to .github/workflows/new.yaml
+index abcdef0..1234567 100644
+--- a/.github/workflows/old.yaml
++++ b/.github/workflows/new.yaml
+@@ -1,3 +1,3 @@
+ name: w
+-on: push
++on: pull_request
+ jobs: {}
+`,
+			want: map[string][]DiffLine{
+				".github/workflows/new.yaml": {
+					{Number: 2, Content: "on: pull_request"},
+				},
+			},
+		},
+		{
+			name: "multiple hunks in one file",
+			diff: `diff --git a/wf.yaml b/wf.yaml
+index 1111111..2222222 100644
+--- a/wf.yaml
++++ b/wf.yaml
+@@ -1,3 +1,3 @@
+ a
+-b
++B
+ c
+@@ -10,3 +10,3 @@ section
+ x
+-y
++Y
+ z
+`,
+			want: map[string][]DiffLine{
+				"wf.yaml": {
+					{Number: 2, Content: "B"},
+					{Number: 11, Content: "Y"},
+				},
+			},
+		},
+		{
+			name: "context lines advance counter but are not targets",
+			diff: `diff --git a/f b/f
+index 1..2 100644
+--- a/f
++++ b/f
+@@ -5,5 +5,6 @@
+ line5
+ line6
++inserted
+ line7
+ line8
+ line9
+`,
+			want: map[string][]DiffLine{
+				"f": {
+					{Number: 7, Content: "inserted"},
+				},
+			},
+		},
+		{
+			name: "no newline at end of file marker is skipped",
+			diff: `diff --git a/f b/f
+index 1..2 100644
+--- a/f
++++ b/f
+@@ -1,2 +1,2 @@
+ a
+-b
+\ No newline at end of file
++B
+\ No newline at end of file
+`,
+			want: map[string][]DiffLine{
+				"f": {
+					{Number: 2, Content: "B"},
+				},
+			},
+		},
+		{
+			name: "empty diff yields empty map",
+			diff: ``,
+			want: map[string][]DiffLine{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseDiff(strings.NewReader(tt.diff))
+			if err != nil {
+				t.Fatalf("ParseDiff() error = %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got.files); diff != "" {
+				t.Errorf("ParseDiff() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDiffFilter_Files(t *testing.T) {
+	t.Parallel()
+	df := &DiffFilter{files: map[string][]DiffLine{
+		"a.yaml": {{Number: 1, Content: "x"}},
+		"b.yaml": {{Number: 2, Content: "y"}},
+	}}
+	got := df.Files()
+	sort.Strings(got)
+	want := []string{"a.yaml", "b.yaml"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Files() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDiffFilter_Has(t *testing.T) {
+	t.Parallel()
+	df := &DiffFilter{files: map[string][]DiffLine{"a.yaml": nil}}
+	// nil-valued key still counts as present; but the parser never inserts
+	// empty entries so this is just for coverage of the lookup itself.
+	if !df.Has("a.yaml") {
+		t.Errorf("Has(a.yaml) = false, want true")
+	}
+	if df.Has("c.yaml") {
+		t.Errorf("Has(c.yaml) = true, want false")
+	}
+}
+
+func TestDiffFilter_Lines(t *testing.T) {
+	t.Parallel()
+	lines := []DiffLine{{Number: 1, Content: "x"}}
+	df := &DiffFilter{files: map[string][]DiffLine{"a.yaml": lines}}
+	if diff := cmp.Diff(lines, df.Lines("a.yaml")); diff != "" {
+		t.Errorf("Lines() mismatch (-want +got):\n%s", diff)
+	}
+	if got := df.Lines("c.yaml"); got != nil {
+		t.Errorf("Lines(c.yaml) = %v, want nil", got)
+	}
+}

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -36,6 +36,9 @@ type ParamRun struct {
 	Now               time.Time
 	Format            string
 	Findings          []Finding
+	// DiffFilter, when set, restricts processing to the `+` lines of a
+	// unified diff. Files not present in the filter are skipped entirely.
+	DiffFilter *DiffFilter
 }
 
 // Exit code classes for the v4 spec.
@@ -79,7 +82,13 @@ func (c *Controller) Run(ctx context.Context, logger *slog.Logger) error {
 	exitCode := ExitCodeOK
 	for _, workflowFilePath := range workflowFilePaths {
 		logger := logger.With("workflow_file", workflowFilePath)
-		code, err := c.runWorkflow(ctx, logger, workflowFilePath)
+		var code int
+		var err error
+		if c.param.DiffFilter != nil {
+			code, err = c.runWorkflowFromDiff(ctx, logger, workflowFilePath)
+		} else {
+			code, err = c.runWorkflow(ctx, logger, workflowFilePath)
+		}
 		if code > exitCode {
 			exitCode = code
 		}
@@ -130,13 +139,63 @@ func (c *Controller) runWorkflow(ctx context.Context, logger *slog.Logger, workf
 	return exitCode, nil
 }
 
+// runWorkflowFromDiff is the diff-filtered counterpart of runWorkflow: only
+// the `+` lines extracted from the unified diff are processed.
+//
+// I/O is minimised. In check mode (Fix=false) the workflow file is never
+// opened. In fix mode the file is opened only if at least one line actually
+// changes; otherwise both read and write are skipped.
+func (c *Controller) runWorkflowFromDiff(ctx context.Context, logger *slog.Logger, workflowFilePath string) (int, error) {
+	exitCode, patches := c.collectDiffPatches(ctx, logger, workflowFilePath)
+	if !c.param.Fix || len(patches) == 0 {
+		return exitCode, nil
+	}
+	if err := c.applyPatches(workflowFilePath, patches); err != nil {
+		return ExitCodeAPIError, err
+	}
+	return exitCode, nil
+}
+
+// collectDiffPatches runs processLine on every `+` line of the diff for
+// workflowFilePath and returns the patches that would change the file.
+func (c *Controller) collectDiffPatches(ctx context.Context, logger *slog.Logger, workflowFilePath string) (int, map[int]string) {
+	exitCode := ExitCodeOK
+	patches := make(map[int]string)
+	for _, dl := range c.param.DiffFilter.Lines(workflowFilePath) {
+		newLine, changed, code := c.processLine(ctx, logger, workflowFilePath, dl.Number, dl.Content)
+		if code > exitCode {
+			exitCode = code
+		}
+		if changed {
+			patches[dl.Number] = newLine
+		}
+	}
+	return exitCode, patches
+}
+
+// applyPatches reads workflowFilePath, applies patches (keyed by 1-based
+// line number) to the corresponding lines, and writes the file back.
+func (c *Controller) applyPatches(workflowFilePath string, patches map[int]string) error {
+	lines, format, err := c.readWorkflow(workflowFilePath)
+	if err != nil {
+		return err
+	}
+	for n, content := range patches {
+		if i := n - 1; i >= 0 && i < len(lines) {
+			lines[i] = content
+		}
+	}
+	return c.writeWorkflow(workflowFilePath, lines, format)
+}
+
 // processLines processes each line in the workflow file.
 // It returns whether any lines were changed and the exit code (max of any line's
 // contribution: ExitCodeOK / ExitCodeNotPinned / ExitCodeUnfixable / ExitCodeAPIError).
 func (c *Controller) processLines(ctx context.Context, logger *slog.Logger, workflowFilePath string, lines []string) (changed bool, exitCode int) {
 	for i, lineS := range lines {
-		lineChanged, code := c.processLine(ctx, logger, workflowFilePath, lines, i, lineS)
+		newLine, lineChanged, code := c.processLine(ctx, logger, workflowFilePath, i+1, lineS)
 		if lineChanged {
+			lines[i] = newLine
 			changed = true
 		}
 		if code > exitCode {
@@ -147,24 +206,31 @@ func (c *Controller) processLines(ctx context.Context, logger *slog.Logger, work
 }
 
 // processLine handles a single line of the workflow: parses it, classifies any
-// error into an exit code, and (when applicable) applies the patched line in
-// place.
-func (c *Controller) processLine(ctx context.Context, logger *slog.Logger, workflowFilePath string, lines []string, i int, lineS string) (changed bool, exitCode int) {
+// error into an exit code, and reports a patched line back to the caller.
+//
+// Returns (newLine, changed, exitCode):
+//   - newLine: the patched line content when changed is true; empty otherwise
+//   - changed: true when the line should be replaced with newLine
+//   - exitCode: per-line exit code contribution
+//
+// processLine has no knowledge of the surrounding file: the caller is
+// responsible for applying newLine if it wants to mutate a line buffer.
+func (c *Controller) processLine(ctx context.Context, logger *slog.Logger, workflowFilePath string, lineNumber int, lineS string) (newLine string, changed bool, exitCode int) {
 	line := &Line{
 		File:   workflowFilePath,
-		Number: i + 1,
+		Number: lineNumber,
 		Line:   lineS,
 	}
 	lineLogger := logger.With(
-		"line_number", i+1,
+		"line_number", lineNumber,
 		"line", lineS,
 	)
 	l, err := c.parseLine(ctx, lineLogger, lineS)
 	if err != nil {
-		return c.handleLineError(ctx, lineLogger, line, lines, i, lineS, l, err)
+		return c.handleLineError(ctx, lineLogger, line, lineS, l, err)
 	}
 	if l == "" || lineS == l {
-		return false, ExitCodeOK
+		return "", false, ExitCodeOK
 	}
 	lineLogger = lineLogger.With("new_line", l)
 	// When Fix is disabled, a changed line counts as "needs pinning" since the
@@ -174,23 +240,21 @@ func (c *Controller) processLine(ctx context.Context, logger *slog.Logger, workf
 	if !c.param.Fix {
 		code = ExitCodeNotPinned
 	}
-	lines[i] = l
 	c.handleChangedLine(ctx, lineLogger, line, l)
-	return true, code
+	return l, true, code
 }
 
 // handleLineError dispatches the per-line error: min-age is a soft error
 // (apply the fix anyway, bump exit code), everything else is logged via
 // handleParseLineError.
-func (c *Controller) handleLineError(ctx context.Context, lineLogger *slog.Logger, line *Line, lines []string, i int, lineS, l string, err error) (changed bool, exitCode int) {
+func (c *Controller) handleLineError(ctx context.Context, lineLogger *slog.Logger, line *Line, lineS, l string, err error) (newLine string, changed bool, exitCode int) {
 	code := classifyLineError(err)
 	if errors.Is(err, ErrMinAge) {
 		// Min-age is a soft error: the fix (if any) is still applied,
 		// the warning is already in the logger, and exit code is bumped.
 		if l != "" && lineS != l {
-			lines[i] = l
 			c.handleChangedLine(ctx, lineLogger, line, l)
-			return true, code
+			return l, true, code
 		}
 		// Already-pinned action whose SHA fails -min-age: no diff to emit,
 		// but surface file:line + the line in the human-readable output so
@@ -205,10 +269,10 @@ func (c *Controller) handleLineError(ctx context.Context, lineLogger *slog.Logge
 		if c.param.IsGitHubActions {
 			fmt.Fprintf(c.param.Stderr, "::error file=%s,line=%d,title=pinact min-age violation::%s\n", line.File, line.Number, err)
 		}
-		return false, code
+		return "", false, code
 	}
 	c.handleParseLineError(ctx, lineLogger, line, err)
-	return false, code
+	return "", false, code
 }
 
 // classifyLineError maps a per-line parse/process error to an exit code class.

--- a/pkg/controller/run/search_file.go
+++ b/pkg/controller/run/search_file.go
@@ -9,8 +9,31 @@ import (
 // It returns workflow file paths from command line arguments if provided,
 // otherwise uses configured file patterns, or falls back to default discovery.
 //
+// When ParamRun.DiffFilter is set, the result is further intersected with the
+// set of files appearing in the unified diff. Paths are compared as-is, which
+// assumes the diff's paths and the discovery results share the same root
+// (typically: pinact is invoked from the repository root).
+//
 // Returns a slice of file paths to process and any error encountered.
 func (c *Controller) searchFiles() ([]string, error) {
+	files, err := c.searchFilesRaw()
+	if err != nil {
+		return nil, err
+	}
+	if c.param.DiffFilter == nil {
+		return files, nil
+	}
+	filtered := files[:0]
+	for _, f := range files {
+		if c.param.DiffFilter.Has(f) {
+			filtered = append(filtered, f)
+		}
+	}
+	return filtered, nil
+}
+
+// searchFilesRaw performs the unfiltered discovery step shared by all modes.
+func (c *Controller) searchFilesRaw() ([]string, error) {
 	if len(c.param.WorkflowFilePaths) != 0 {
 		return c.param.WorkflowFilePaths, nil
 	}

--- a/pkg/di/flag.go
+++ b/pkg/di/flag.go
@@ -43,6 +43,11 @@ type Flags struct {
 	Exclude     []string
 	BranchToTag []string
 	Args        []string
+
+	// DiffFile is the path to a unified diff. When non-empty, only the
+	// post-image `+` lines of the diff are processed. The literal "-"
+	// reads the diff from stdin.
+	DiffFile string
 }
 
 const defaultGitHubAPIURL = "https://api.github.com"

--- a/pkg/di/run.go
+++ b/pkg/di/run.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"time"
@@ -55,6 +56,13 @@ func Run(ctx context.Context, logger *slogutil.Logger, flags *Flags, secrets *Se
 	if err != nil {
 		return err
 	}
+	if flags.DiffFile != "" {
+		df, err := loadDiffFilter(flags.DiffFile, os.Stdin)
+		if err != nil {
+			return err
+		}
+		param.DiffFilter = df
+	}
 	services, err := setupGHESServices(ctx, gh, cfg, flags, secrets.GHESToken)
 	if err != nil {
 		return err
@@ -62,6 +70,27 @@ func Run(ctx context.Context, logger *slogutil.Logger, flags *Flags, secrets *Se
 
 	ctrl := run.New(services.repoService, services.gitService, fs, cfg, param)
 	return ctrl.Run(ctx, logger.Logger) //nolint:wrapcheck
+}
+
+// loadDiffFilter reads a unified diff from path (or stdin when path is "-")
+// and parses it into a DiffFilter.
+func loadDiffFilter(path string, stdin io.Reader) (*run.DiffFilter, error) {
+	var r io.Reader
+	if path == "-" {
+		r = stdin
+	} else {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("open diff file: %w", err)
+		}
+		defer f.Close()
+		r = f
+	}
+	df, err := run.ParseDiff(r)
+	if err != nil {
+		return nil, fmt.Errorf("parse diff file: %w", err)
+	}
+	return df, nil
 }
 
 func getSeparator(cfg *config.Config, flags *Flags, getEnv func(string) string) string {

--- a/testdata/diff-file/action.yaml
+++ b/testdata/diff-file/action.yaml
@@ -1,0 +1,11 @@
+---
+name: test
+on: workflow_call
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@v3.6.0
+      - uses: actions/setup-go@v4.0.0
+      - uses: actions/cache@v3.3.1

--- a/testdata/diff-file/action_after.yaml
+++ b/testdata/diff-file/action_after.yaml
@@ -1,0 +1,11 @@
+---
+name: test
+on: workflow_call
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@v3.6.0
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+      - uses: actions/cache@v3.3.1

--- a/testdata/diff-file/diff.txt
+++ b/testdata/diff-file/diff.txt
@@ -1,0 +1,11 @@
+diff --git a/testdata/diff-file/action.yaml b/testdata/diff-file/action.yaml
+index 0000001..0000002 100644
+--- a/testdata/diff-file/action.yaml
++++ b/testdata/diff-file/action.yaml
+@@ -7,5 +7,5 @@ jobs:
+     permissions: {}
+     steps:
+       - uses: actions/checkout@v3.6.0
+-      - uses: actions/setup-go@v3.5.0
++      - uses: actions/setup-go@v4.0.0
+       - uses: actions/cache@v3.3.1


### PR DESCRIPTION
## Summary

Adds a `--diff-file` flag to `pinact run` that takes a unified diff (or `-` for stdin) and limits pinact to the post-image `+` lines of the diff. The intended use case is CI: in a PR job, generate the PR diff and pass it to pinact so only lines the PR actually changed are reported / fixed.

```sh
pinact run --diff-file pr.diff
git diff origin/main...HEAD | pinact run --diff-file -
```

## Behavior

- The new flag lives alongside the existing flags; the previously existing `--diff` flag (a `--fix=false` alias) is unaffected.
- Files NOT present in the unified diff are dropped from file discovery, so neither file discovery (`searchFiles`) nor `readWorkflow` is called for them. This applies in both check and fix modes.
- Per-line processing only runs on the `+` lines of the diff. Lines outside the diff are not parsed and do not contribute to `findings` / SARIF / GitHub Actions annotations / exit code.
- Existing filters (`--include` / `--exclude` / `--branch-to-tag` / config `ignore` / etc.) are still applied — the diff filter is composed with them as AND.
- Workflow file paths supplied as positional arguments are also intersected with the diff (so passing a file that the diff doesn't touch is a no-op).

### I/O minimisation

| Mode | File read | File write |
| --- | --- | --- |
| `--fix=false` (check / diff / SARIF) | never | never |
| `--fix=true` (default) | only when at least one `+` line actually needs to change | only when at least one `+` line actually needs to change |

In check mode the workflow file is never opened — the `+` line content from the diff body is itself the post-image content, so it can be fed straight into `parseLine`. In fix mode, `readWorkflow`/`writeWorkflow` are deferred until after the `+` lines have been processed and proven to require at least one patch; if every diff line is already pinned, the file is left untouched (verified locally via md5 round-trip).

## Implementation

- **New**: `pkg/controller/run/diff_filter.go` — `DiffFilter` parses a unified diff with `github.com/sourcegraph/go-diff/diff`, walks each hunk's body (`+` adds + advances new-file counter, ` ` advances only, `-` and `\` skip), strips `a/`/`b/` path prefixes, follows renames via `NewName`, drops files that are deleted (`NewName == /dev/null`).
- **New**: `pkg/controller/run/diff_filter_internal_test.go` — 8 cases covering single hunk, multi-hunk, new file, deleted file, rename + edit, context lines, no-newline-at-EOF marker, empty diff.
- **Refactor**: `processLine` / `handleLineError` no longer mutate `lines []string` in place. They return `(newLine string, changed bool, exitCode int)`, and the caller (`processLines` for the normal path, `runWorkflowFromDiff` for the diff path) decides what to do with the new line. This lets the diff path reuse the exact same per-line logic without going through a line buffer.
- **New**: `runWorkflowFromDiff` (and its helpers `collectDiffPatches` / `applyPatches`) implement the lazy-I/O flow described above.
- **Modified**: `searchFiles` now calls `searchFilesRaw` (the previous discovery logic, unchanged) and then intersects the result with `DiffFilter.Has()` when a filter is set. Paths are compared as-is, which assumes pinact is invoked from the repository root (the documented norm for `.github/workflows/...`).
- **CLI / DI**: `--diff-file <path>` (`StringFlag`) → `di.Flags.DiffFile` → `di.loadDiffFilter` reads from `os.Stdin` when path is `-`, otherwise opens the file, parses, and sets `ParamRun.DiffFilter`.

## Edge cases handled

| Case | Behavior |
| --- | --- |
| diff file does not exist | fatal at startup |
| diff file is empty | nothing to do, exit 0 |
| diff parse error | fatal |
| path in diff but not on disk | dropped by `searchFiles` intersection, no read attempt |
| rename-only / mode-change-only file (no `+` lines) | excluded |
| new file (orig is `/dev/null`) | every body line is `+`, so all lines are targets |
| deleted file (new is `/dev/null`) | excluded |
| `\ No newline at end of file` marker | skipped during hunk body walk |
| CRLF / trailing-newline preservation | `detectFileFormat` is still in charge; fix-mode write goes through the existing `writeWorkflow` path |

## Test plan

- [x] `cmdx v` (`go vet ./...`) clean
- [x] `cmdx t` (`go test -race -covermode=atomic ./...`) all green; new tests in `diff_filter_internal_test.go` pass
- [x] golangci-lint clean (pre-commit hook)
- [x] Manual E2E:
  - [x] `--diff-file <path>` reports only `+` lines (`exit=1` in check mode for needs-pinning)
  - [x] `--diff-file -` reads from stdin
  - [x] Fix mode rewrites the file with the pinned SHA
  - [x] Passing a workflow file as a positional arg that is not in the diff is skipped (no output, exit 0)
  - [x] Fix mode with a diff whose every `+` line is already pinned leaves the file's md5 unchanged (no write)

## Notes / future work

- Paths in the diff are matched against `searchFiles` results as-is, so this PR assumes pinact runs at the repository root. Supporting `CWD != repo root` is out of scope for this initial version.
- Environment variable (`PINACT_DIFF_FILE`) and integration with `github.com/suzuki-shunsuke/go-pr-diff` are deliberately out of scope; they can be layered on top in follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)