### PR TITLE
fix: honor rules[].min_age in update-target cooldown filter

### DIFF
--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
+	"github.com/suzuki-shunsuke/pinact/v4/pkg/config"
 	"github.com/suzuki-shunsuke/pinact/v4/pkg/github"
 	"github.com/suzuki-shunsuke/slog-error/slogerr"
 )
@@ -28,19 +29,18 @@ type GitService interface {
 // getLatestVersion determines the latest version of a repository.
 // It first tries to get the latest version from releases, and if that fails
 // or returns empty, it falls back to getting the latest version from tags.
-func (c *Controller) getLatestVersion(ctx context.Context, logger *slog.Logger, owner, repo, currentVersion string) (string, error) {
-	return c.getLatestVersionWithStable(ctx, logger, owner, repo, isStableVersion(currentVersion))
+func (c *Controller) getLatestVersion(ctx context.Context, logger *slog.Logger, owner, repo, currentVersion string, resolved *config.Resolved) (string, error) {
+	return c.getLatestVersionWithStable(ctx, logger, owner, repo, isStableVersion(currentVersion), resolved)
 }
 
 // getLatestVersionWithStable is the same as getLatestVersion but takes an
 // explicit isStable flag instead of inferring it from currentVersion. Used by
 // branch-to-tag, which has no semver-shaped currentVersion to infer from.
-func (c *Controller) getLatestVersionWithStable(ctx context.Context, logger *slog.Logger, owner, repo string, isStable bool) (string, error) {
-	// Calculate cutoff once for min-age filtering. We use the global fallback
-	// (CLI > config > env) rather than effectiveMinAge because rule resolution
-	// has not been threaded down here; see minAgeFallback's TODO.
+func (c *Controller) getLatestVersionWithStable(ctx context.Context, logger *slog.Logger, owner, repo string, isStable bool, resolved *config.Resolved) (string, error) {
+	// Calculate cutoff once for min-age filtering. Honors per-rule overrides
+	// via effectiveMinAge (CLI > rules > config).
 	var cutoff time.Time
-	if mAge := c.minAgeFallback(); mAge > 0 {
+	if mAge := c.effectiveMinAge(resolved); mAge > 0 {
 		cutoff = c.param.Now.AddDate(0, 0, -mAge)
 	}
 

--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -166,7 +166,7 @@ func (c *Controller) parseLine(ctx context.Context, logger *slog.Logger, line st
 		return "", nil
 	}
 
-	newLine, err := c.processAction(ctx, logger, action, attrs)
+	newLine, err := c.processAction(ctx, logger, action, attrs, resolved)
 	if err != nil {
 		return newLine, err
 	}
@@ -192,19 +192,14 @@ func (c *Controller) effectiveMinAge(resolved *config.Resolved) int {
 	if c.param.MinAge > 0 {
 		return c.param.MinAge
 	}
-	if resolved.MinAge != nil {
+	if resolved != nil && resolved.MinAge != nil {
 		return *resolved.MinAge
 	}
 	return c.minAgeFallback()
 }
 
-// minAgeFallback returns the threshold for contexts where per-rule overrides
-// are not yet available (e.g. the update-target cooldown filter in
-// getLatestVersionWithStable, which runs inside processAction before rule
-// resolution is plumbed through). Precedence is CLI / env > config.min_age.value.
-//
-// TODO: thread the resolved rule into the update path so rules[].min_age can
-// also override the update-target cooldown filter (currently global-only).
+// minAgeFallback returns the threshold for contexts where no resolved rule is
+// available. Precedence is CLI / env > config.min_age.value.
 func (c *Controller) minAgeFallback() int {
 	if c.param.MinAge > 0 {
 		return c.param.MinAge
@@ -294,7 +289,7 @@ func (c *Controller) shouldSkipAction(logger *slog.Logger, action *Action) bool 
 // When -no-api is set, processAction short-circuits any GitHub API call:
 // already-pinned SHAs are accepted as-is and everything else is reported as
 // unfixable (ExitCodeUnfixable).
-func (c *Controller) processAction(ctx context.Context, logger *slog.Logger, action *Action, attrs *slogerr.Attrs) (string, error) {
+func (c *Controller) processAction(ctx context.Context, logger *slog.Logger, action *Action, attrs *slogerr.Attrs, resolved *config.Resolved) (string, error) {
 	if c.param.NoAPI {
 		if getVersionType(action.Version) == FullCommitSHA {
 			return "", nil
@@ -303,26 +298,26 @@ func (c *Controller) processAction(ctx context.Context, logger *slog.Logger, act
 	}
 	switch getVersionType(action.Version) {
 	case FullCommitSHA:
-		return c.processPinnedVersion(ctx, logger, action, attrs)
+		return c.processPinnedVersion(ctx, logger, action, attrs, resolved)
 	case Semver, Shortsemver:
-		return c.processTaggedVersion(ctx, logger, action)
+		return c.processTaggedVersion(ctx, logger, action, resolved)
 	default:
-		return c.processUnpinnedVersion(ctx, logger, action)
+		return c.processUnpinnedVersion(ctx, logger, action, resolved)
 	}
 }
 
 // processPinnedVersion handles actions whose Version is already a full commit
 // SHA. The comment determines whether to verify, expand a short tag, or
 // update to a newer release.
-func (c *Controller) processPinnedVersion(ctx context.Context, logger *slog.Logger, action *Action, attrs *slogerr.Attrs) (string, error) {
+func (c *Controller) processPinnedVersion(ctx context.Context, logger *slog.Logger, action *Action, attrs *slogerr.Attrs, resolved *config.Resolved) (string, error) {
 	switch getVersionType(action.VersionComment) {
 	case Semver:
 		// @<sha> # v1.0.0
-		return c.processPinnedSemverComment(ctx, logger, action)
+		return c.processPinnedSemverComment(ctx, logger, action, resolved)
 	case Shortsemver:
 		// @<sha> # v1
 		logger = attrs.Add(logger, "version_annotation", action.VersionComment)
-		return c.processPinnedShortsemverComment(ctx, logger, action)
+		return c.processPinnedShortsemverComment(ctx, logger, action, resolved)
 	default:
 		// Empty (@<sha>) or Other (@<sha> # hoge): already pinned, leave alone.
 		return "", nil
@@ -330,11 +325,11 @@ func (c *Controller) processPinnedVersion(ctx context.Context, logger *slog.Logg
 }
 
 // processPinnedSemverComment handles @<sha> # v1.0.0.
-func (c *Controller) processPinnedSemverComment(ctx context.Context, logger *slog.Logger, action *Action) (string, error) {
+func (c *Controller) processPinnedSemverComment(ctx context.Context, logger *slog.Logger, action *Action, resolved *config.Resolved) (string, error) {
 	if !c.param.Update {
 		return c.verifyIfNeeded(ctx, logger, action)
 	}
-	lv, err := c.getLatestVersion(ctx, logger, action.RepoOwner, action.RepoName, action.VersionComment)
+	lv, err := c.getLatestVersion(ctx, logger, action.RepoOwner, action.RepoName, action.VersionComment, resolved)
 	if err != nil {
 		return "", fmt.Errorf("get the latest version: %w", err)
 	}
@@ -349,9 +344,9 @@ func (c *Controller) processPinnedSemverComment(ctx context.Context, logger *slo
 }
 
 // processPinnedShortsemverComment handles @<sha> # v1.
-func (c *Controller) processPinnedShortsemverComment(ctx context.Context, logger *slog.Logger, action *Action) (string, error) {
+func (c *Controller) processPinnedShortsemverComment(ctx context.Context, logger *slog.Logger, action *Action, resolved *config.Resolved) (string, error) {
 	if c.param.Update {
-		lv, err := c.getLatestVersion(ctx, logger, action.RepoOwner, action.RepoName, action.VersionComment)
+		lv, err := c.getLatestVersion(ctx, logger, action.RepoOwner, action.RepoName, action.VersionComment, resolved)
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)
 		}
@@ -372,13 +367,13 @@ func (c *Controller) processPinnedShortsemverComment(ctx context.Context, logger
 // processTaggedVersion handles actions whose Version is a semver or short
 // semver tag. These are unpinned and must be pinned to a commit SHA, or
 // updated to the latest version when --update is set.
-func (c *Controller) processTaggedVersion(ctx context.Context, logger *slog.Logger, action *Action) (string, error) {
+func (c *Controller) processTaggedVersion(ctx context.Context, logger *slog.Logger, action *Action, resolved *config.Resolved) (string, error) {
 	typ := getVersionType(action.Version)
 	switch getVersionType(action.VersionComment) {
 	case Empty:
 		// @v1 or @v1.0.0
 		if c.param.Update {
-			return c.updateToLatestVersion(ctx, logger, action)
+			return c.updateToLatestVersion(ctx, logger, action, resolved)
 		}
 		return c.pinCurrentVersion(ctx, logger, action, typ)
 	case Semver:
@@ -386,7 +381,7 @@ func (c *Controller) processTaggedVersion(ctx context.Context, logger *slog.Logg
 		if !c.param.Update {
 			return c.pinCurrentVersion(ctx, logger, action, typ)
 		}
-		lv, err := c.getLatestVersion(ctx, logger, action.RepoOwner, action.RepoName, action.VersionComment)
+		lv, err := c.getLatestVersion(ctx, logger, action.RepoOwner, action.RepoName, action.VersionComment, resolved)
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)
 		}
@@ -403,18 +398,18 @@ func (c *Controller) processTaggedVersion(ctx context.Context, logger *slog.Logg
 
 // processUnpinnedVersion handles actions whose Version is neither a SHA nor
 // a semver tag (typically a branch name like main).
-func (c *Controller) processUnpinnedVersion(ctx context.Context, logger *slog.Logger, action *Action) (string, error) {
+func (c *Controller) processUnpinnedVersion(ctx context.Context, logger *slog.Logger, action *Action, resolved *config.Resolved) (string, error) {
 	switch getVersionType(action.VersionComment) {
 	case Empty:
 		if c.matchBranchToTag(action.Version) {
-			return c.convertBranchToLatestTag(ctx, logger, action)
+			return c.convertBranchToLatestTag(ctx, logger, action, resolved)
 		}
 		return "", ErrCantPinned
 	case Semver:
 		if !c.param.Update {
 			return "", ErrCantPinned
 		}
-		lv, err := c.getLatestVersion(ctx, logger, action.RepoOwner, action.RepoName, action.VersionComment)
+		lv, err := c.getLatestVersion(ctx, logger, action.RepoOwner, action.RepoName, action.VersionComment, resolved)
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)
 		}
@@ -463,13 +458,13 @@ func (c *Controller) matchBranchToTag(v string) bool {
 // branch name) to the latest stable tag of the action's repository and pins
 // the line to its commit SHA. Falls back to including pre-releases only when
 // no stable tag exists.
-func (c *Controller) convertBranchToLatestTag(ctx context.Context, logger *slog.Logger, action *Action) (string, error) {
-	lv, err := c.getLatestVersionWithStable(ctx, logger, action.RepoOwner, action.RepoName, true)
+func (c *Controller) convertBranchToLatestTag(ctx context.Context, logger *slog.Logger, action *Action, resolved *config.Resolved) (string, error) {
+	lv, err := c.getLatestVersionWithStable(ctx, logger, action.RepoOwner, action.RepoName, true, resolved)
 	if err != nil {
 		return "", fmt.Errorf("get the latest stable version: %w", err)
 	}
 	if lv == "" {
-		lv, err = c.getLatestVersionWithStable(ctx, logger, action.RepoOwner, action.RepoName, false)
+		lv, err = c.getLatestVersionWithStable(ctx, logger, action.RepoOwner, action.RepoName, false, resolved)
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)
 		}
@@ -485,8 +480,8 @@ func (c *Controller) convertBranchToLatestTag(ctx context.Context, logger *slog.
 }
 
 // updateToLatestVersion updates an action to its latest version.
-func (c *Controller) updateToLatestVersion(ctx context.Context, logger *slog.Logger, action *Action) (string, error) {
-	lv, err := c.getLatestVersion(ctx, logger, action.RepoOwner, action.RepoName, action.Version)
+func (c *Controller) updateToLatestVersion(ctx context.Context, logger *slog.Logger, action *Action, resolved *config.Resolved) (string, error) {
+	lv, err := c.getLatestVersion(ctx, logger, action.RepoOwner, action.RepoName, action.Version, resolved)
 	if err != nil {
 		return "", fmt.Errorf("get the latest version: %w", err)
 	}

--- a/pkg/controller/run/parse_line_internal_test.go
+++ b/pkg/controller/run/parse_line_internal_test.go
@@ -909,6 +909,73 @@ func TestController_parseLine_branchToTag(t *testing.T) { //nolint:funlen
 	}
 }
 
+// TestController_parseLine_update_ruleMinAge verifies that rules[].min_age
+// overrides the global min_age.value when selecting the update target during
+// `pinact run -u`. With the global cutoff (3 days) v2.0.0 would be filtered out,
+// but the rule sets min_age to 0 so the recent release must be picked.
+func TestController_parseLine_update_ruleMinAge(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	tags := &github.ListTagsResult{
+		Tags: []*github.RepositoryTag{
+			{Name: new("v2.0.0"), Commit: &github.Commit{SHA: new("2222222222222222222222222222222222222222")}},
+			{Name: new("v1.0.0"), Commit: &github.Commit{SHA: new("1111111111111111111111111111111111111111")}},
+		},
+		Response: &github.Response{},
+	}
+	releases := &github.ListReleasesResult{
+		Releases: []*github.RepositoryRelease{
+			{TagName: new("v2.0.0"), PublishedAt: &github.Timestamp{Time: now.AddDate(0, 0, -1)}},
+			{TagName: new("v1.0.0"), PublishedAt: &github.Timestamp{Time: now.AddDate(0, 0, -30)}},
+		},
+		Response: &github.Response{},
+	}
+	commits := map[string]*github.GetCommitSHA1Result{
+		"aquaproj/example/v2.0.0": {SHA: "2222222222222222222222222222222222222222"},
+	}
+
+	three := 3
+	zero := 0
+	cfg := &config.Config{
+		Separator: " # ",
+		MinAge:    &config.MinAge{Value: &three},
+		Rules: []*config.Rule{
+			{
+				MinAge: &zero,
+				Conditions: []*config.Condition{
+					{Expr: `ActionRepoOwner == "aquaproj"`},
+				},
+			},
+		},
+	}
+	for i, r := range cfg.Rules {
+		if err := r.Init(); err != nil {
+			t.Fatalf("init rules[%d]: %v", i, err)
+		}
+	}
+
+	fs := afero.NewMemMapFs()
+	ctrl := New(&github.RepositoriesServiceImpl{
+		Tags:     map[string]*github.ListTagsResult{"aquaproj/example/0": tags},
+		Releases: map[string]*github.ListReleasesResult{"aquaproj/example/0": releases},
+		Commits:  commits,
+	}, nil, fs, cfg, &ParamRun{
+		Update: true,
+		Now:    now,
+	})
+	logger := slog.New(slog.DiscardHandler)
+
+	line := "  - uses: aquaproj/example@1111111111111111111111111111111111111111 # v1.0.0"
+	got, err := ctrl.parseLine(t.Context(), logger, line)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "  - uses: aquaproj/example@2222222222222222222222222222222222222222 # v2.0.0"
+	if got != want {
+		t.Fatalf("rules[].min_age=0 should override cooldown:\n  want %s\n  got  %s", want, got)
+	}
+}
+
 // TestController_checkSHAMinAge_boundary verifies that the passive -min-age
 // check returns ErrMinAge when the commit is younger than the cutoff and
 // returns nil when it is older. The mock GitService is reused from


### PR DESCRIPTION
## Summary

Previously, a per-action `rules[].min_age` override only suppressed the **passive audit** (`checkSHAMinAge`), not the **update-target cooldown filter** inside `getLatestVersionWithStable`. As a result, even with a rule like:

```yaml
min_age:
  value: 3
rules:
  - min_age: 0
    conditions:
      - expr: ActionRepoOwner == "aquaproj"
```

`pinact run -u` still emitted `skip release due to cooldown` for matched actions, because the cutoff was computed from the global-only `minAgeFallback` helper (CLI/env > `config.min_age.value`) and rule resolution had not been threaded down into the update path. A `TODO` in `minAgeFallback` documented this gap.

## Changes

- `pkg/controller/run/parse_line.go`
  - Thread the already-resolved `*config.Resolved` from `parseLine` through `processAction` and into every downstream branch:
    - `processPinnedVersion` / `processPinnedSemverComment` / `processPinnedShortsemverComment`
    - `processTaggedVersion` / `updateToLatestVersion`
    - `processUnpinnedVersion` / `convertBranchToLatestTag`
  - Make `effectiveMinAge` nil-safe so callers without a resolved rule (e.g., tests) still work.
  - Drop the `TODO` from `minAgeFallback`; rule resolution is now plumbed through.
- `pkg/controller/run/github.go`
  - Add `resolved *config.Resolved` to `getLatestVersion` and `getLatestVersionWithStable`.
  - Compute the cooldown cutoff via `c.effectiveMinAge(resolved)` instead of `c.minAgeFallback()`, so the precedence becomes CLI/env > `rules[].min_age` > `config.min_age.value`, matching the documented behavior of `effectiveMinAge` and the existing passive-audit path.
- `pkg/controller/run/parse_line_internal_test.go`
  - Add `TestController_parseLine_update_ruleMinAge` covering the user-reported scenario: global `min_age.value: 3` plus a rule with `min_age: 0` for `aquaproj` actions; `pinact run -u` against a pinned-SHA + semver-comment line picks the recent release instead of skipping it for cooldown.

## Behavior

- A rule that sets `min_age: 0` now disables the cooldown filter for the matched action both during the update target search and during the passive audit.
- The CLI `-min-age` flag / `PINACT_MIN_AGE` env still wins over rules and config, as before.
- When no rule matches, behavior is unchanged: `config.min_age.value` is used.

## Test plan

- [x] `cmdx v` (`go vet ./...`)
- [x] `cmdx t` (`go test ./... -race -covermode=atomic`) — all packages pass, new test covers the regression.
- [ ] Manual: run `pinact run -u` in a repo with the rule above against an aquaproj action that has a release younger than `min_age.value` and confirm the new release is picked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)