### PR TITLE
fix(run): use --diff-file as the file source when no args/config

### DIFF
--- a/pkg/controller/run/search_file.go
+++ b/pkg/controller/run/search_file.go
@@ -35,12 +35,22 @@ func (c *Controller) searchFiles() ([]string, error) {
 }
 
 // searchFilesRaw performs the unfiltered discovery step shared by all modes.
+//
+// When the user has not provided explicit args or configured file patterns
+// and a -diff-file is set, the diff's file list becomes the source. This
+// makes `pinact run --fix=false --diff-file ...` work even when the
+// workflow files are not present on disk (e.g. a CI job that validates a
+// PR diff without running actions/checkout): runWorkflowFromDiff reads
+// only from the diff content in check mode, so the disk is never touched.
 func (c *Controller) searchFilesRaw() ([]string, error) {
 	if len(c.param.WorkflowFilePaths) != 0 {
 		return c.param.WorkflowFilePaths, nil
 	}
 	if c.cfg != nil && len(c.cfg.Files) > 0 {
 		return c.searchFilesByGlob()
+	}
+	if c.param.DiffFilter != nil {
+		return c.param.DiffFilter.Files(), nil
 	}
 	return listWorkflows()
 }

--- a/pkg/controller/run/search_file_internal_test.go
+++ b/pkg/controller/run/search_file_internal_test.go
@@ -1,8 +1,10 @@
 package run
 
 import (
+	"sort"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/pinact/v4/pkg/config"
 )
@@ -102,6 +104,58 @@ func TestController_searchFiles_withWorkflowPaths(t *testing.T) {
 
 	if len(got) != 3 {
 		t.Errorf("searchFiles() got %d files, want 3", len(got))
+	}
+}
+
+// When no args/config files are set, a -diff-file becomes the source of
+// file paths. This lets `pinact run --fix=false --diff-file ...` work
+// without requiring the workflow files to be present on disk.
+func TestController_searchFiles_diffFileAsSource(t *testing.T) {
+	t.Parallel()
+	df := &DiffFilter{files: map[string][]DiffLine{
+		".github/workflows/test.yaml": {{Number: 1, Content: "x"}},
+		"composite/foo/bar/baz/qux/action.yml": {
+			{Number: 2, Content: "y"},
+		},
+	}}
+	ctrl := New(nil, nil, afero.NewMemMapFs(), nil, &ParamRun{DiffFilter: df})
+
+	got, err := ctrl.searchFiles()
+	if err != nil {
+		t.Fatalf("searchFiles() error = %v", err)
+	}
+	sort.Strings(got)
+	want := []string{
+		".github/workflows/test.yaml",
+		"composite/foo/bar/baz/qux/action.yml",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("searchFiles() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// Explicit args still win over a -diff-file: the args define the candidate
+// set and the diff filter intersects it.
+func TestController_searchFiles_argsWithDiffFile(t *testing.T) {
+	t.Parallel()
+	df := &DiffFilter{files: map[string][]DiffLine{
+		"a.yaml": {{Number: 1, Content: "x"}},
+		"c.yaml": {{Number: 2, Content: "y"}},
+	}}
+	ctrl := New(nil, nil, afero.NewMemMapFs(), &config.Config{}, &ParamRun{
+		WorkflowFilePaths: []string{"a.yaml", "b.yaml"},
+		DiffFilter:        df,
+	})
+
+	got, err := ctrl.searchFiles()
+	if err != nil {
+		t.Fatalf("searchFiles() error = %v", err)
+	}
+	// "b.yaml" is in args but not in the diff -> filtered out.
+	// "c.yaml" is in the diff but not in args -> not in source.
+	want := []string{"a.yaml"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("searchFiles() mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Summary

When neither command-line args nor configured `files` are set, fall back to `DiffFilter.Files()` instead of `filepath.Glob` for the discovery step in `searchFilesRaw`.

## Why

`pinact run --fix=false --diff-file ...` is meant for CI jobs that validate a PR diff without checking out the repository. In check mode, `runWorkflowFromDiff` only reads from the parsed diff content (never the disk), so the workflow files don't need to exist locally.

The old discovery path required `filepath.Glob` to find candidate files first, then intersected the result with the diff. When the workspace was empty (no `actions/checkout`), glob returned nothing, so the intersection was empty and pinact silently exited 0 with no output — even though the diff clearly contained unpinned actions.

Concrete failure scenario: [szksh-lab-2/test-github-action#381](https://github.com/szksh-lab-2/test-github-action/pull/381) configures `fix: false`, `no_api: true`, `diff_file: <PR diff>` without `actions/checkout`; the diff added unpinned action references, but pinact silently exited 0.

## Behavior

| args | config `files` | `--diff-file` | source (before) | source (after) |
|---|---|---|---|---|
| set | — | — | args | args (unchanged) |
| set | — | set | args ∩ diff | args ∩ diff (unchanged) |
| — | set | — | config glob | config glob (unchanged) |
| — | set | set | config glob ∩ diff | config glob ∩ diff (unchanged) |
| — | — | — | listWorkflows glob | listWorkflows glob (unchanged) |
| — | — | **set** | **listWorkflows ∩ diff** | **`DiffFilter.Files()`** |

Only the last row changes. Explicit args and config still take precedence.

## Side benefit

Deeply nested `**/action.{yml,yaml}` files beyond the 3-level glob hardcoded in `listWorkflows` are now picked up when they appear in the diff.

## Notes

- In fix mode with `--diff-file` but no checkout, `applyPatches` will fail when it tries to read the file — that's a noisy and informative failure, strictly better than the silent exit 0 today.
- `DiffFilter.Files()` may return non-workflow paths (e.g. `.go`, `.md` files in the diff). pinact's per-line processing only matches `uses:` patterns, so these files yield zero findings. Overhead is small and avoids hardcoding workflow-shape filters in the discovery layer.

## Test plan

- [x] `go test ./... -race -covermode=atomic` passes
- [x] `go vet ./...` and `golangci-lint run` pass (pre-existing goconst issue in `list_workflows.go` was inadvertently tripped by the new test data; resolved by using a different filename in the test)
- [ ] Re-run szksh-lab-2/test-github-action#381 after this lands and confirm the action fails on the unpinned references in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)