### PR TITLE
feat!: require version comment on SHA-pinned actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ $ pinact run
 1. [Offline check without GitHub API](#offline-check--no-api)
 1. [Update actions](#update-actions--update) with a [minimum release age](#minimum-release-age-cooldown--min-age--verify-min-age)
 1. [Verify version comments](docs/codes/001.md) ([`-verify-comment`](#verify-version-comments--verify-comment--verify--v))
+1. [Require a version comment on SHA-pinned actions](docs/codes/005.md)
 1. [Verify if actions meet the minimum release age](#minimum-release-age-cooldown--min-age)
 1. [Pin branches](#pin-branches--branch-to-tag)
 1. [Include and exclude specific actions](#include-and-exclude-specific-actions)
@@ -368,7 +369,7 @@ For more details, see [Configuration File](docs/config.md).
 | --- | --- |
 | 0 | Everything is pinned, or pinact fixed it |
 | 1 | `-fix=false` was set and something needs pinning |
-| 2 | An action cannot be auto-fixed (branch reference, `-verify-comment` mismatch, or `-min-age` violation) |
+| 2 | An action cannot be auto-fixed (branch reference, [missing version comment on a SHA pin](docs/codes/005.md), `-verify-comment` mismatch, or `-min-age` violation) |
 | 3 | GitHub API error, invalid CLI flag combination, or other unexpected error |
 
 ## GitHub Actions

--- a/docs/codes/005.md
+++ b/docs/codes/005.md
@@ -1,0 +1,49 @@
+# SHA-pinned action requires a version comment
+
+This error means a workflow contains a `uses:` line pinned to a full commit SHA but missing the trailing `# <version>` comment, and pinact cannot cross-verify the SHA against any upstream tag.
+
+```yaml
+# Error: bare SHA with no comment
+- uses: owner/repo@e7500cdc5165d144721128822d9018f7be4eb43e
+
+# OK: SHA backed by an upstream tag
+- uses: owner/repo@e7500cdc5165d144721128822d9018f7be4eb43e # v1.2.3
+```
+
+## Why is this an error?
+
+`owner/repo@<SHA>` is resolved across the entire GitHub fork network. An attacker who lacks push access to the upstream repository can still push a commit to a fork, producing a `<SHA>` that the `uses:` line will happily resolve to. Without an accompanying tag comment, neither pinact nor a human reviewer can tell whether the SHA belongs to the upstream repository or to a fork.
+
+When the version comment is present, pinact's `--verify-comment` mode confirms that the SHA matches the SHA actually pointed to by the named tag on the upstream repository, closing the fork-network gap.
+
+A secondary benefit: bare SHAs that have been removed from the upstream history (deleted tags, rebased branches) are silently undetectable. Requiring a verifiable comment surfaces them too.
+
+## How to resolve
+
+### 1. Let pinact add the comment
+
+If the SHA corresponds to an upstream tag, run pinact without `-no-api`:
+
+```sh
+pinact run
+```
+
+pinact will look up the tag and rewrite the line as `@<SHA> # <tag>`.
+
+### 2. Drop `-no-api`
+
+`-no-api` disables the GitHub API call that resolves SHA to tag. Without it pinact has no way to verify the SHA, so any SHA-pinned action without a comment is rejected. Re-run without `-no-api` (at least once) to populate the comments.
+
+### 3. Ignore legitimate untagged SHAs
+
+For SHAs that intentionally have no upstream tag (internal forks, pre-release pins, vendored composite actions), opt out with `rules` in `.pinact.yaml`:
+
+```yaml
+rules:
+  - ignore: true
+    conditions:
+      - expr: |
+          ActionName == "owner/repo" && ActionVersion == "e7500cdc5165d144721128822d9018f7be4eb43e"
+```
+
+The matched action is skipped entirely, including this check.

--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -81,7 +81,10 @@ func parseAction(line string) *Action {
 	}
 }
 
-var ErrCantPinned = errors.New("action can't be pinned")
+var (
+	ErrCantPinned            = errors.New("action can't be pinned")
+	ErrMissingVersionComment = errors.New("SHA-pinned action requires a version comment for verifiability")
+)
 
 // ignoreAction checks if an action should be ignored based on configuration.
 // It evaluates the action against all ignore rules in the configuration.
@@ -287,11 +290,19 @@ func (c *Controller) shouldSkipAction(logger *slog.Logger, action *Action) bool 
 // the comment refines the behavior inside each branch.
 //
 // When -no-api is set, processAction short-circuits any GitHub API call:
-// already-pinned SHAs are accepted as-is and everything else is reported as
-// unfixable (ExitCodeUnfixable).
+// already-pinned SHAs with a version comment are accepted as-is; SHAs without
+// a comment cannot be cross-verified against any upstream tag (no API to look
+// it up), so they are rejected as ErrMissingVersionComment. Everything else
+// is reported as unfixable (ExitCodeUnfixable).
 func (c *Controller) processAction(ctx context.Context, logger *slog.Logger, action *Action, attrs *slogerr.Attrs, resolved *config.Resolved) (string, error) {
 	if c.param.NoAPI {
 		if getVersionType(action.Version) == FullCommitSHA {
+			if getVersionType(action.VersionComment) == Empty {
+				return "", slogerr.With( //nolint:wrapcheck
+					ErrMissingVersionComment,
+					"docs", "https://github.com/suzuki-shunsuke/pinact/blob/main/docs/codes/005.md",
+				)
+			}
 			return "", nil
 		}
 		return "", ErrCantPinned
@@ -483,13 +494,19 @@ func (c *Controller) convertBranchToLatestTag(ctx context.Context, logger *slog.
 }
 
 // addMissingComment looks up the tag for a pinned commit SHA and adds the version comment.
+// If no upstream tag points at the SHA, returns ErrMissingVersionComment: the SHA cannot
+// be cross-verified against an upstream tag, which is the safety guarantee version
+// comments are meant to provide.
 func (c *Controller) addMissingComment(ctx context.Context, logger *slog.Logger, action *Action) (string, error) {
 	v, err := c.getLongVersionFromSHA(ctx, logger, action, action.Version)
 	if err != nil {
 		return "", err
 	}
 	if v == "" {
-		return "", nil
+		return "", slogerr.With( //nolint:wrapcheck
+			ErrMissingVersionComment,
+			"docs", "https://github.com/suzuki-shunsuke/pinact/blob/main/docs/codes/005.md",
+		)
 	}
 	return c.patchLine(action, action.Version, v), nil
 }
@@ -661,7 +678,8 @@ func (c *Controller) verify(ctx context.Context, logger *slog.Logger, action *Ac
 			return "", fmt.Errorf("find version for SHA: %w", err)
 		}
 		if correctVersion != "" {
-			logger.Warn("version annotation mismatch detected, correcting comment",
+			logger.Warn(
+				"version annotation mismatch detected, correcting comment",
 				"action", action.Name,
 				"action_version", action.Version,
 				"version_annotation", action.VersionComment,

--- a/pkg/controller/run/parse_line_internal_test.go
+++ b/pkg/controller/run/parse_line_internal_test.go
@@ -174,8 +174,9 @@ func TestController_parseLine(t *testing.T) { //nolint:funlen
 			exp:  `  - 'uses': "actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab" # v3.5.2`,
 		},
 		{
-			name: "pinned SHA without comment - no matching tag",
-			line: "  - uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			name:  "pinned SHA without comment - no matching tag",
+			line:  "  - uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			isErr: true,
 		},
 		{
 			name: "multi-space after dash",
@@ -260,6 +261,7 @@ func TestController_parseLine_addMissingComment(t *testing.T) { //nolint:funlen
 		commits map[string]*github.GetCommitSHA1Result
 		line    string
 		exp     string
+		wantErr error
 	}{
 		{
 			name: "semver tag found directly",
@@ -347,7 +349,7 @@ func TestController_parseLine_addMissingComment(t *testing.T) { //nolint:funlen
 			exp:  "  - uses: actions/checkout@" + sha + " # 2.11.5",
 		},
 		{
-			name: "only non-version tags - pinned SHA unchanged",
+			name: "only non-version tags - error because SHA can't be cross-verified",
 			tags: []*github.RepositoryTag{
 				{
 					Name:   new("latest"),
@@ -358,7 +360,25 @@ func TestController_parseLine_addMissingComment(t *testing.T) { //nolint:funlen
 					Commit: &github.Commit{SHA: new(sha)},
 				},
 			},
-			line: "  - uses: actions/checkout@" + sha,
+			line:    "  - uses: actions/checkout@" + sha,
+			wantErr: ErrMissingVersionComment,
+		},
+		{
+			name:    "no tags at all - error because SHA can't be cross-verified",
+			tags:    []*github.RepositoryTag{},
+			line:    "  - uses: actions/checkout@" + sha,
+			wantErr: ErrMissingVersionComment,
+		},
+		{
+			name: "tag exists but for a different SHA - error",
+			tags: []*github.RepositoryTag{
+				{
+					Name:   new("v1.0.0"),
+					Commit: &github.Commit{SHA: new("0000000000000000000000000000000000000000")},
+				},
+			},
+			line:    "  - uses: actions/checkout@" + sha,
+			wantErr: ErrMissingVersionComment,
 		},
 	}
 	logger := slog.New(slog.DiscardHandler)
@@ -388,11 +408,62 @@ func TestController_parseLine_addMissingComment(t *testing.T) { //nolint:funlen
 				Separator: " # ",
 			}, &ParamRun{})
 			line, err := ctrl.parseLine(t.Context(), logger, d.line)
+			if d.wantErr != nil {
+				if !errors.Is(err, d.wantErr) {
+					t.Fatalf("wanted error %v, got %v", d.wantErr, err)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatal(err)
 			}
 			if line != d.exp {
 				t.Fatalf("wanted %s, got %s", d.exp, line)
+			}
+		})
+	}
+}
+
+func TestController_parseLine_noAPI(t *testing.T) {
+	t.Parallel()
+	sha := "8e5e7e5ab8b370d6c329ec480221332ada57f0ab"
+	data := []struct {
+		name    string
+		line    string
+		wantErr error
+	}{
+		{
+			name: "pinned SHA with version comment is accepted",
+			line: "  - uses: actions/checkout@" + sha + " # v3.5.2",
+		},
+		{
+			name:    "pinned SHA without version comment is rejected",
+			line:    "  - uses: actions/checkout@" + sha,
+			wantErr: ErrMissingVersionComment,
+		},
+		{
+			name:    "tag reference is rejected (can't pin without API)",
+			line:    "  - uses: actions/checkout@v3",
+			wantErr: ErrCantPinned,
+		},
+	}
+	logger := slog.New(slog.DiscardHandler)
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			t.Parallel()
+			fs := afero.NewMemMapFs()
+			ctrl := New(nil, nil, fs, &config.Config{
+				Separator: " # ",
+			}, &ParamRun{NoAPI: true})
+			_, err := ctrl.parseLine(t.Context(), logger, d.line)
+			if d.wantErr != nil {
+				if !errors.Is(err, d.wantErr) {
+					t.Fatalf("wanted error %v, got %v", d.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
 			}
 		})
 	}

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -276,10 +276,11 @@ func (c *Controller) handleLineError(ctx context.Context, lineLogger *slog.Logge
 }
 
 // classifyLineError maps a per-line parse/process error to an exit code class.
-//   - ErrCantPinned / ErrUnfixable / ErrMinAge / verify mismatch -> ExitCodeUnfixable (2)
-//   - ErrAPI / anything else                                     -> ExitCodeAPIError  (3)
+//   - ErrCantPinned / ErrUnfixable / ErrMinAge / ErrMissingVersionComment /
+//     verify mismatch -> ExitCodeUnfixable (2)
+//   - ErrAPI / anything else -> ExitCodeAPIError (3)
 func classifyLineError(err error) int {
-	if errors.Is(err, ErrCantPinned) || errors.Is(err, ErrUnfixable) || errors.Is(err, ErrMinAge) {
+	if errors.Is(err, ErrCantPinned) || errors.Is(err, ErrUnfixable) || errors.Is(err, ErrMinAge) || errors.Is(err, ErrMissingVersionComment) {
 		return ExitCodeUnfixable
 	}
 	return ExitCodeAPIError


### PR DESCRIPTION
## Summary

Treat a SHA-pinned `uses:` line without a `# v...` version comment as an error in two paths that previously fell through silently:

1. `addMissingComment` (`pkg/controller/run/parse_line.go`) — when no upstream tag resolves to the pinned SHA, the line was left unchanged with no diagnostic. Now returns `ErrMissingVersionComment`.
2. `processAction` `-no-api` branch (`pkg/controller/run/parse_line.go`) — full-SHA pins were accepted regardless of comment presence. Now rejects bare SHAs (no comment) because there is no API to reverse-look-up a tag for verification.

Both sites map to `ExitCodeUnfixable` (2) via `classifyLineError` in `pkg/controller/run/run.go`. The error is wrapped with `slogerr.With` carrying a `docs` slog attribute that points to the new `docs/codes/005.md` page.

## Why

`owner/repo@<SHA>` resolves across the entire GitHub fork network. An attacker who lacks push access to the upstream repository can push to a fork and produce a `<SHA>` that the `uses:` line will happily resolve to. Without an accompanying tag comment, neither pinact nor a human reviewer can tell whether the SHA belongs to upstream or a fork. The version comment is what lets `--verify-comment` cross-check the SHA against the tag on the upstream repository.

Secondary benefit: bare SHAs that have been removed from upstream history (deleted tags, rebased branches) are silently undetectable. Requiring a verifiable comment surfaces them too.

## Changes by file

- **`pkg/controller/run/parse_line.go`** — new `ErrMissingVersionComment` sentinel; `addMissingComment` returns it (wrapped with the `docs` attribute) when the SHA-to-tag reverse lookup yields nothing; `processAction` `-no-api` branch now checks `getVersionType(action.VersionComment) == Empty` before short-circuiting and returns the same error if true.
- **`pkg/controller/run/run.go`** — `classifyLineError` extended to recognise the new sentinel and route it to `ExitCodeUnfixable`. Doc comment updated.
- **`pkg/controller/run/parse_line_internal_test.go`** — three additions to `TestController_parseLine_addMissingComment` covering empty-tag-list, only-non-version-tags, and SHA-mismatched-tag scenarios; the existing "pinned SHA without comment - no matching tag" case in `TestController_parseLine` is flipped from silent-pass to `isErr: true`; new `TestController_parseLine_noAPI` function with three cases covering `-no-api` with a SHA + comment, `-no-api` with a bare SHA, and `-no-api` with a tag reference.
- **`docs/codes/005.md`** — new error-code page explaining the failure and three resolution paths (`pinact run` to auto-add, drop `-no-api`, or `rules[].ignore` for legitimate untagged SHAs).
- **`README.md`** — Features list and Exit codes table updated to mention the new check and link to `docs/codes/005.md`.

## BREAKING CHANGE

Workflows that contain a SHA-pinned action whose SHA does not correspond to any upstream tag, or that use `-no-api` against any SHA without a `# v...` comment, will now exit with code `2`.

Migration:
- Run `pinact run` once (without `-no-api`) to let pinact reverse-look-up SHAs and auto-add the missing comments.
- For SHAs that intentionally have no upstream tag (internal forks, pre-release pins, vendored composite actions), opt out with `rules[].ignore` in `.pinact.yaml`. See `docs/codes/005.md` for the exact `expr` form.

## Test plan

- [x] `cmdx v` (`go vet ./...`) passes
- [x] `cmdx t` (`go test -race -covermode=atomic ./...`) passes including the three new test cases in `TestController_parseLine_addMissingComment`, the flipped case in `TestController_parseLine`, and the new `TestController_parseLine_noAPI`
- [x] Manual: bare SHA in a workflow without `-no-api` exits with code 2 and the human-readable error names the offending line
- [x] Manual: bare SHA with `-no-api -fix=false` exits with code 2; SHA-with-comment with `-no-api -fix=false` exits with code 0
- [x] Manual: `.pinact.yaml` with `rules[].ignore: true` matching the offending action via `ActionName` / `ActionVersion` suppresses the error (exit code 0)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)