### PR TITLE
fix(run): filter --diff-file targets by workflow patterns

### DIFF
--- a/pkg/controller/run/list_workflows.go
+++ b/pkg/controller/run/list_workflows.go
@@ -7,26 +7,35 @@ import (
 	"github.com/suzuki-shunsuke/slog-error/slogerr"
 )
 
+// defaultWorkflowPatterns is the set of glob patterns used to discover GitHub
+// Actions workflow and composite action files when neither command line args
+// nor a config file provide explicit target patterns. The patterns use `/` as
+// the path separator and are intended for both filepath.Glob (disk discovery)
+// and path.Match (filtering an already-known set of paths, e.g. from
+// --diff-file).
+//
+//nolint:gochecknoglobals // shared read-only pattern list used for both disk discovery (filepath.Glob) and diff filtering (path.Match)
+var defaultWorkflowPatterns = []string{
+	".github/workflows/*.yml",
+	".github/workflows/*.yaml",
+	"action.yml",
+	"action.yaml",
+	"*/action.yml",
+	"*/action.yaml",
+	"*/*/action.yml",
+	"*/*/action.yaml",
+	"*/*/*/action.yml",
+	"*/*/*/action.yaml",
+}
+
 // listWorkflows discovers GitHub Actions workflow and composite action files.
 // It searches for YAML files in standard locations including .github/workflows
 // and action.yaml files in various directory structures.
 //
 // Returns a slice of discovered file paths or an error if globbing fails.
 func listWorkflows() ([]string, error) {
-	patterns := []string{
-		".github/workflows/*.yml",
-		".github/workflows/*.yaml",
-		"action.yml",
-		"action.yaml",
-		"*/action.yml",
-		"*/action.yaml",
-		"*/*/action.yml",
-		"*/*/action.yaml",
-		"*/*/*/action.yml",
-		"*/*/*/action.yaml",
-	}
 	files := []string{}
-	for _, pattern := range patterns {
+	for _, pattern := range defaultWorkflowPatterns {
 		matches, err := filepath.Glob(pattern)
 		if err != nil {
 			return nil, fmt.Errorf("look for workflow or composite action files using glob: %w", slogerr.With(err, "pattern", pattern))

--- a/pkg/controller/run/search_file.go
+++ b/pkg/controller/run/search_file.go
@@ -2,57 +2,98 @@ package run
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 )
 
 // searchFiles determines which files to process based on configuration.
-// It returns workflow file paths from command line arguments if provided,
-// otherwise uses configured file patterns, or falls back to default discovery.
 //
-// When ParamRun.DiffFilter is set, the result is further intersected with the
-// set of files appearing in the unified diff. DiffFilter normalizes lookup
-// paths via filepath.ToSlash internally, so OS-native paths (e.g. Windows
-// backslashes from filepath.Glob) match the slash-delimited diff keys. The
-// comparison still assumes the diff's paths and the discovery results share
-// the same root (typically: pinact is invoked from the repository root).
+// When ParamRun.DiffFilter is nil (the normal case), it resolves the
+// candidate set from explicit args, configured file patterns, or default
+// discovery -- all via filepath.Glob against the local filesystem.
+//
+// When ParamRun.DiffFilter is set, the candidate set always starts from the
+// files present in the diff (DiffFilter.Files()). It is then narrowed using
+// path.Match -- never touching the disk -- so that `pinact run --diff-file`
+// works in CI jobs that have not checked out the workflow files. The filter
+// is the intersection of the diff with:
+//   - the explicit args (WorkflowFilePaths), if any; otherwise
+//   - the configured cfg.Files patterns (relative to the config dir), if any;
+//     otherwise
+//   - the package default patterns (defaultWorkflowPatterns).
 //
 // Returns a slice of file paths to process and any error encountered.
 func (c *Controller) searchFiles() ([]string, error) {
-	files, err := c.searchFilesRaw()
-	if err != nil {
-		return nil, err
-	}
 	if c.param.DiffFilter == nil {
-		return files, nil
+		return c.searchFilesFromDisk()
 	}
-	filtered := files[:0]
-	for _, f := range files {
-		if c.param.DiffFilter.Has(f) {
-			filtered = append(filtered, f)
-		}
-	}
-	return filtered, nil
+	return c.searchFilesFromDiff()
 }
 
-// searchFilesRaw performs the unfiltered discovery step shared by all modes.
-//
-// When the user has not provided explicit args or configured file patterns
-// and a -diff-file is set, the diff's file list becomes the source. This
-// makes `pinact run --fix=false --diff-file ...` work even when the
-// workflow files are not present on disk (e.g. a CI job that validates a
-// PR diff without running actions/checkout): runWorkflowFromDiff reads
-// only from the diff content in check mode, so the disk is never touched.
-func (c *Controller) searchFilesRaw() ([]string, error) {
+// searchFilesFromDisk is the non-diff path: it resolves the candidate set by
+// walking the local filesystem (explicit args > config patterns > defaults).
+func (c *Controller) searchFilesFromDisk() ([]string, error) {
 	if len(c.param.WorkflowFilePaths) != 0 {
 		return c.param.WorkflowFilePaths, nil
 	}
 	if c.cfg != nil && len(c.cfg.Files) > 0 {
 		return c.searchFilesByGlob()
 	}
-	if c.param.DiffFilter != nil {
-		return c.param.DiffFilter.Files(), nil
-	}
 	return listWorkflows()
+}
+
+// searchFilesFromDiff intersects the diff's file set with the configured
+// target (args / cfg.Files / defaultWorkflowPatterns) using path.Match.
+// Diff paths are already slash-delimited (ParseDiff normalises them), which
+// matches path.Match's separator convention.
+func (c *Controller) searchFilesFromDiff() ([]string, error) {
+	diffFiles := c.param.DiffFilter.Files()
+
+	if len(c.param.WorkflowFilePaths) != 0 {
+		allowed := make(map[string]struct{}, len(c.param.WorkflowFilePaths))
+		for _, p := range c.param.WorkflowFilePaths {
+			allowed[filepath.ToSlash(p)] = struct{}{}
+		}
+		filtered := make([]string, 0, len(diffFiles))
+		for _, f := range diffFiles {
+			if _, ok := allowed[f]; ok {
+				filtered = append(filtered, f)
+			}
+		}
+		return filtered, nil
+	}
+
+	if c.cfg != nil && len(c.cfg.Files) > 0 {
+		configFileDir := filepath.ToSlash(filepath.Dir(c.param.ConfigFilePath))
+		patterns := make([]string, 0, len(c.cfg.Files))
+		for _, file := range c.cfg.Files {
+			patterns = append(patterns, path.Join(configFileDir, file.Pattern))
+		}
+		return matchAny(patterns, diffFiles)
+	}
+
+	return matchAny(defaultWorkflowPatterns, diffFiles)
+}
+
+// matchAny returns the subset of files matching at least one of patterns,
+// evaluated with path.Match. It preserves the input order of files and does
+// not deduplicate (the input is expected to come from DiffFilter.Files(),
+// which already has unique keys).
+func matchAny(patterns, files []string) ([]string, error) {
+	out := make([]string, 0, len(files))
+	for _, f := range files {
+		for _, p := range patterns {
+			ok, err := path.Match(p, f)
+			if err != nil {
+				return nil, fmt.Errorf("match diff file against pattern %q: %w", p, err)
+			}
+			if ok {
+				out = append(out, f)
+				break
+			}
+		}
+	}
+	return out, nil
 }
 
 // searchFilesByGlob finds files using glob patterns from configuration.

--- a/pkg/controller/run/search_file_internal_test.go
+++ b/pkg/controller/run/search_file_internal_test.go
@@ -108,15 +108,18 @@ func TestController_searchFiles_withWorkflowPaths(t *testing.T) {
 }
 
 // When no args/config files are set, a -diff-file becomes the source of
-// file paths. This lets `pinact run --fix=false --diff-file ...` work
-// without requiring the workflow files to be present on disk.
+// file paths, filtered by the default workflow/action patterns via path.Match.
+// This lets `pinact run --fix=false --diff-file ...` work without requiring
+// the workflow files to be present on disk, while still excluding unrelated
+// files that happen to appear in the diff (README.md, source code, etc.).
 func TestController_searchFiles_diffFileAsSource(t *testing.T) {
 	t.Parallel()
 	df := &DiffFilter{files: map[string][]DiffLine{
 		".github/workflows/test.yaml": {{Number: 1, Content: "x"}},
-		"composite/foo/bar/baz/qux/action.yml": {
-			{Number: 2, Content: "y"},
-		},
+		"composite/foo/action.yml":    {{Number: 2, Content: "y"}},
+		"README.md":                   {{Number: 3, Content: "z"}},
+		// Too deep for the default patterns (max */*/*/action.yml).
+		"composite/foo/bar/baz/qux/action.yml": {{Number: 4, Content: "q"}},
 	}}
 	ctrl := New(nil, nil, afero.NewMemMapFs(), nil, &ParamRun{DiffFilter: df})
 
@@ -127,8 +130,38 @@ func TestController_searchFiles_diffFileAsSource(t *testing.T) {
 	sort.Strings(got)
 	want := []string{
 		".github/workflows/test.yaml",
-		"composite/foo/bar/baz/qux/action.yml",
+		"composite/foo/action.yml",
 	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("searchFiles() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// When cfg.Files patterns are present and -diff-file is set, the diff's
+// files are filtered by those patterns via path.Match (no disk access).
+func TestController_searchFiles_diffFileWithConfigPatterns(t *testing.T) {
+	t.Parallel()
+	df := &DiffFilter{files: map[string][]DiffLine{
+		"a.yaml":     {{Number: 1, Content: "x"}},
+		"dir/b.yaml": {{Number: 2, Content: "y"}},
+		"c.txt":      {{Number: 3, Content: "z"}},
+	}}
+	cfg := &config.Config{
+		Files: []*config.File{{Pattern: "*.yaml"}},
+	}
+	ctrl := New(nil, nil, afero.NewMemMapFs(), cfg, &ParamRun{
+		ConfigFilePath: ".pinact.yaml",
+		DiffFilter:     df,
+	})
+
+	got, err := ctrl.searchFiles()
+	if err != nil {
+		t.Fatalf("searchFiles() error = %v", err)
+	}
+	sort.Strings(got)
+	// "*.yaml" matches a.yaml but not dir/b.yaml (path.Match's `*` does not
+	// cross `/`), and c.txt is excluded.
+	want := []string{"a.yaml"}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("searchFiles() mismatch (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
## Summary

When `--diff-file` is set, the candidate file set now starts from the diff and is narrowed using `path.Match` against the same targeting rules used for normal runs (args, `cfg.Files`, or the default workflow / action patterns). Previously, when neither args nor `cfg.Files` were provided (the case added in #1557 / dcc9b52), every file in the diff was processed -- including unrelated files like `README.md` or source code that happened to appear in the patch.

The intent for `--diff-file` is **intersection (AND)**, not union (OR):

| Mode | Candidate set | Filter |
|---|---|---|
| args specified | diff files | files exactly matching args |
| `cfg.Files` specified | diff files | `path.Match` against `cfg.Files[].Pattern` (joined with config dir) |
| neither | diff files | `path.Match` against `defaultWorkflowPatterns` |

When `--diff-file` is not set, behaviour is unchanged: discovery still walks the filesystem via `filepath.Glob`.

## Why path.Match (and not filepath.Glob)?

The original motivation for #1557 was to let `pinact run --diff-file` work in CI jobs that have not checked out the workflow files (`runWorkflowFromDiff` already reads only from the diff in check mode). Using `filepath.Glob` to filter the diff would require those files to exist on disk, which would defeat that use case.

`path.Match` evaluates the patterns against the (already slash-delimited) diff paths in memory, so the disk is never touched. This also matches how `pkg/config/config.go` already validates `cfg.Files[].Pattern` syntax (via `path.Match`), keeping the semantics consistent end-to-end.

## Changes

### `pkg/controller/run/list_workflows.go`
- Extracted the default workflow / composite-action glob patterns from the body of `listWorkflows()` into a package-level `defaultWorkflowPatterns` variable so they can be shared with the diff-driven path. `listWorkflows()` still uses `filepath.Glob` for disk discovery.

### `pkg/controller/run/search_file.go`
- Split `searchFiles` into two paths: `searchFilesFromDisk` (no diff, unchanged behaviour) and `searchFilesFromDiff` (new, in-memory filtering).
- `searchFilesFromDiff` starts from `DiffFilter.Files()` and intersects it with args / `cfg.Files` patterns / `defaultWorkflowPatterns`, in that priority order.
- For the args case, args are normalised with `filepath.ToSlash` for Windows compatibility before set membership testing.
- For the `cfg.Files` case, patterns are joined with the config directory via `path.Join` (slash-only) before matching.
- New helper `matchAny(patterns, files)` runs `path.Match` and preserves input order.
- The old `searchFilesRaw` is removed; `searchFilesByGlob` remains for the disk path.

### `pkg/controller/run/search_file_internal_test.go`
- Updated `TestController_searchFiles_diffFileAsSource` to assert that default patterns filter the diff: a `README.md` in the diff and a too-deep `composite/foo/bar/baz/qux/action.yml` (deeper than `*/*/*/action.yml`) are excluded, while `.github/workflows/test.yaml` and `composite/foo/action.yml` are kept.
- Added `TestController_searchFiles_diffFileWithConfigPatterns` covering the `cfg.Files` + diff case: a config pattern of `*.yaml` filters `a.yaml` through but excludes `dir/b.yaml` (since `path.Match`'s `*` does not cross `/`) and `c.txt`.
- `TestController_searchFiles_argsWithDiffFile` is unchanged and still passes (args ∩ diff was already correct).

## Compatibility

No public API changes. Behaviour change for existing `--diff-file` users:

- Previously, with no args and no `cfg.Files`, any file in the diff was processed. Now only files matching the default workflow / action patterns are. This is the intended behaviour -- pinact only operates on `uses:` lines in GitHub Actions YAML, so non-workflow files were never useful targets and only risked noise (e.g. the `feat!` from f96ba15 that errors on SHA-pinned actions without version comments would otherwise misfire on unrelated files).
- For users who relied on `cfg.Files` glob patterns combined with `--diff-file`, the intersection is now computed in memory rather than from disk -- so workflows that exist only in the diff (not on disk) are correctly handled.

## Test plan

- [x] `cmdx v` (`go vet ./...`) passes
- [x] `cmdx t` (`go test -race -covermode=atomic ./...`) passes
- [x] `TestController_searchFiles_diffFileAsSource` exercises the default-pattern filter
- [x] `TestController_searchFiles_diffFileWithConfigPatterns` exercises the `cfg.Files` filter
- [x] `TestController_searchFiles_argsWithDiffFile` still asserts args ∩ diff
- [ ] Manual smoke: build pinact and run `pinact run --diff-file=...` against a diff that contains both `.github/workflows/foo.yaml` and `README.md`, confirm only the former is processed