### PR TITLE
feat(run): add --keep-major to keep updates within the current major

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ pinact run
 1. [Check if actions are pinned without editing files](#just-validation--check--fixfalse)
 1. [Offline check without GitHub API](#offline-check--no-api)
 1. [Update actions](#update-actions--update) with a [minimum release age](#minimum-release-age-cooldown--min-age--verify-min-age)
+1. [Restrict updates to the current major version](#major-version-lock---keep-major)
 1. [Verify version comments](docs/codes/001.md) ([`-verify-comment`](#verify-version-comments--verify-comment--verify--v))
 1. [Require a version comment on SHA-pinned actions](docs/codes/005.md)
 1. [Verify if actions meet the minimum release age](#minimum-release-age-cooldown--min-age)
@@ -152,6 +153,32 @@ On the other hand, when updating actions min_age setting is always used to filte
 
 - For GitHub Releases, the `PublishedAt` date is checked
 - For tags, the commit's `Committer.Date` is checked (requires additional API call)
+
+### Major Version Lock: `--keep-major`
+
+`--keep-major` restricts `pinact run -u` to releases within the same major version as the current pin. For an action pinned at `v4.3.1`, updates are limited to the `v4.x.y` series and a published `v5.0.0` (or higher) is skipped.
+
+```sh
+pinact run -u --keep-major
+```
+
+This is useful for actions that ship breaking changes between major versions, where you want to keep pulling in patch and minor updates without auditing a new major.
+
+The current major is parsed from the existing version comment (e.g. `# v4.3.1`). If the comment cannot be parsed as semver, pinact emits a warning and falls back to the unconstrained behavior so the run can still upgrade.
+
+You can also enable it in the configuration file, either globally or per action:
+
+```yaml
+keep_major: true # default false
+rules:
+  # Opt a specific action out of the major-lock.
+  - keep_major: false
+    conditions:
+      - expr: |
+          ActionRepoFullName == "actions/checkout"
+```
+
+Precedence for the per-action effective value is: matching `rules[].keep_major` > CLI flag `--keep-major` > top-level `keep_major` > default `false`. Rules take the highest precedence so a per-action opt-out is honored even when `--keep-major` is set globally.
 
 ### Verify Version Comments: `-verify-comment` (`-verify`, `-v`)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -77,6 +77,7 @@ When both a project-level configuration (e.g. `.pinact.yaml`) and a global confi
 | `ghes` | project if set (whole-object replace), otherwise global |
 | `min_age.value` | project if set, otherwise global |
 | `min_age.always` | project if set, otherwise global (so a global `always: true` survives when the project doesn't mention it) |
+| `keep_major` | project if set, otherwise global |
 | `ignore_actions` | concatenated as `[global..., project...]` |
 | `rules` | concatenated as `[global..., project...]` (later rules win per-field under the existing rule resolution semantics) |
 
@@ -137,6 +138,13 @@ rules:
     conditions:
       - expr: |
           ActionName matches "suzuki-shunsuke/.*" && ActionVersion == "main"
+  - keep_major: true
+    conditions:
+      - expr: |
+          ActionRepoOwner == "actions"
+
+# Restrict -u to releases within the same major version (optional, default false)
+keep_major: false
 ```
 
 ### `files`
@@ -185,6 +193,11 @@ rules:
     conditions:
       - expr: |
           ActionRepoFullName == "actions/checkout"
+  # Stay within the current major version for these actions when -u is set.
+  - keep_major: true
+    conditions:
+      - expr: |
+          ActionRepoOwner == "actions"
 ```
 
 #### `rules[].ignore`
@@ -196,6 +209,12 @@ This is optional. If `true`, pinact skips pin/update/error reporting for the mat
 This is optional. Overrides the min-age threshold (in days) for the matched action. Setting it to `0` disables the min-age check for the action.
 
 The effective min-age for an action is resolved in this order: CLI flag `-min-age` > matching rules > top-level `min_age`.
+
+#### `rules[].keep_major`
+
+This is optional. Overrides the [`keep_major`](#keep_major) setting for the matched action. Setting it to `true` restricts `-u` to releases within the same major version as the current pin; `false` opts the action out (even when `--keep-major` is passed on the CLI or `keep_major: true` is set at the top level).
+
+The effective value for an action is resolved in this order: matching rules > CLI flag `--keep-major` > top-level `keep_major`. Rules take the highest precedence so a per-action opt-out is honored.
 
 #### `rules[].conditions`
 
@@ -225,6 +244,16 @@ pinact >= v4.0.0
 This is optional. The default min-age in days for the min-age check. When set, pinact checks that every action's pinned commit is at least this many days old, and exits with code 2 on violation.
 
 The top-level value can be overridden by the CLI flag `-min-age` (highest precedence) or per-action by `rules[].min_age`.
+
+### `keep_major`
+
+This is optional. Default is `false`.
+
+When `true`, `pinact run -u` skips releases whose major version differs from the current pin's version comment, so updates stay within the same major series (e.g. an action pinned at `v4.3.1` is only upgraded to `v4.x.y`, never `v5.0.0`). This is useful for actions that ship breaking changes between majors.
+
+The major is parsed from the existing version comment (`# v4.3.1`). If the comment cannot be parsed as semver, pinact emits a warning and falls back to the unconstrained behavior so the run can still upgrade.
+
+The top-level value can be overridden by the CLI flag `--keep-major` or per-action by [`rules[].keep_major`](#ruleskeep_major). The CLI flag is also useful for one-off runs: `pinact run -u --keep-major`.
 
 ### `ignore_actions`
 

--- a/json-schema/pinact.json
+++ b/json-schema/pinact.json
@@ -51,6 +51,10 @@
           "$ref": "#/$defs/MinAge",
           "description": "Default min-age settings. value is the threshold in days; always opts every run into the passive audit. rules can override value per action"
         },
+        "keep_major": {
+          "type": "boolean",
+          "description": "When true -u skips releases whose major version differs from the current pin's version comment. Default false"
+        },
         "rules": {
           "items": {
             "$ref": "#/$defs/Rule"
@@ -129,6 +133,10 @@
         "min_age": {
           "type": "integer",
           "description": "Override the min-age threshold (in days) for the matched action. 0 disables the check for the action"
+        },
+        "keep_major": {
+          "type": "boolean",
+          "description": "Override the keep-major setting for the matched action. true restricts -u to the same major version as the current pin; false opts the action out"
         },
         "conditions": {
           "items": {

--- a/pkg/cli/run/command.go
+++ b/pkg/cli/run/command.go
@@ -168,6 +168,11 @@ $ pinact run .github/actions/foo/action.yaml .github/actions/bar/action.yaml
 					return nil
 				},
 			},
+			&cli.BoolFlag{
+				Name:        "keep-major",
+				Usage:       "Restrict -u to releases within the same major version as the current pin's version comment",
+				Destination: &flags.KeepMajor,
+			},
 			&cli.StringFlag{
 				Name:        "separator",
 				Aliases:     []string{"sep"},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	GHES          *GHES           `json:"ghes,omitempty" yaml:"ghes" jsonschema:"description=GitHub Enterprise Server configuration"`
 	Separator     string          `json:"separator,omitempty" jsonschema:"description=Separator between version and tag comment. Default is ' # '"`
 	MinAge        *MinAge         `json:"min_age,omitzero" yaml:"min_age" jsonschema:"description=Default min-age settings. value is the threshold in days; always opts every run into the passive audit. rules can override value per action"`
+	KeepMajor     *bool           `json:"keep_major,omitempty" yaml:"keep_major" jsonschema:"description=When true -u skips releases whose major version differs from the current pin's version comment. Default false"`
 	Rules         []*Rule         `json:"rules,omitempty" jsonschema:"description=Per-action setting overrides. Later matching rules override earlier ones at the field level"`
 }
 
@@ -172,6 +173,7 @@ func (ia *IgnoreAction) initRef() error {
 type Rule struct {
 	Ignore     *bool        `json:"ignore,omitempty" jsonschema:"description=If true pinact skips pin/update/error for the matched action"`
 	MinAge     *int         `json:"min_age,omitempty" yaml:"min_age" jsonschema:"description=Override the min-age threshold (in days) for the matched action. 0 disables the check for the action"`
+	KeepMajor  *bool        `json:"keep_major,omitempty" yaml:"keep_major" jsonschema:"description=Override the keep-major setting for the matched action. true restricts -u to the same major version as the current pin; false opts the action out"`
 	Conditions []*Condition `json:"conditions,omitempty" jsonschema:"description=Match conditions. The rule matches if any condition evaluates to true"`
 }
 
@@ -196,10 +198,13 @@ type MatchInput struct {
 // Resolved is the merged result of all rules that matched a given action.
 // MinAge is a pointer because nil means "no rule overrode min_age", which is
 // distinct from a rule explicitly setting min_age to 0 (which disables the
-// check for that action).
+// check for that action). KeepMajor is a pointer for the same reason: nil
+// means "no rule overrode keep_major", which is distinct from a rule
+// explicitly opting the action in or out.
 type Resolved struct {
-	Ignore bool
-	MinAge *int
+	Ignore    bool
+	MinAge    *int
+	KeepMajor *bool
 }
 
 var (
@@ -278,6 +283,9 @@ func (cfg *Config) ResolveRules(input *MatchInput) (*Resolved, error) {
 		}
 		if r.MinAge != nil {
 			res.MinAge = r.MinAge
+		}
+		if r.KeepMajor != nil {
+			res.KeepMajor = r.KeepMajor
 		}
 	}
 	return res, nil
@@ -521,6 +529,9 @@ func mergeConfig(global, project *Config) *Config {
 	out.IgnoreActions = append(append([]*IgnoreAction(nil), global.IgnoreActions...), project.IgnoreActions...)
 	out.Rules = append(append([]*Rule(nil), global.Rules...), project.Rules...)
 	out.MinAge = mergeMinAge(global.MinAge, project.MinAge)
+	if project.KeepMajor == nil {
+		out.KeepMajor = global.KeepMajor
+	}
 	return &out
 }
 

--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -518,10 +518,11 @@ func TestConfig_ResolveRules(t *testing.T) { //nolint:funlen
 	}
 
 	tests := []struct {
-		name       string
-		rules      []*Rule
-		wantIgnore bool
-		wantMinAge *int
+		name          string
+		rules         []*Rule
+		wantIgnore    bool
+		wantMinAge    *int
+		wantKeepMajor *bool
 	}{
 		{
 			name:       "no rules",
@@ -606,6 +607,46 @@ func TestConfig_ResolveRules(t *testing.T) { //nolint:funlen
 			wantIgnore: false,
 			wantMinAge: new(0),
 		},
+		{
+			name: "rule sets keep_major true",
+			rules: []*Rule{
+				{
+					KeepMajor:  new(true),
+					Conditions: []*Condition{{Expr: `ActionRepoOwner == "actions"`}},
+				},
+			},
+			wantIgnore:    false,
+			wantMinAge:    nil,
+			wantKeepMajor: new(true),
+		},
+		{
+			name: "rule sets keep_major false (explicit opt-out)",
+			rules: []*Rule{
+				{
+					KeepMajor:  new(false),
+					Conditions: []*Condition{{Expr: `ActionName == "actions/checkout"`}},
+				},
+			},
+			wantIgnore:    false,
+			wantMinAge:    nil,
+			wantKeepMajor: new(false),
+		},
+		{
+			name: "later matching rule overrides keep_major",
+			rules: []*Rule{
+				{
+					KeepMajor:  new(true),
+					Conditions: []*Condition{{Expr: `ActionRepoOwner == "actions"`}},
+				},
+				{
+					KeepMajor:  new(false),
+					Conditions: []*Condition{{Expr: `ActionName == "actions/checkout"`}},
+				},
+			},
+			wantIgnore:    false,
+			wantMinAge:    nil,
+			wantKeepMajor: new(false),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -628,6 +669,14 @@ func TestConfig_ResolveRules(t *testing.T) { //nolint:funlen
 				t.Errorf("MinAge: got %v, want %v", got.MinAge, tt.wantMinAge)
 			case *got.MinAge != *tt.wantMinAge:
 				t.Errorf("MinAge: got %d, want %d", *got.MinAge, *tt.wantMinAge)
+			}
+			switch {
+			case got.KeepMajor == nil && tt.wantKeepMajor == nil:
+				// ok
+			case got.KeepMajor == nil || tt.wantKeepMajor == nil:
+				t.Errorf("KeepMajor: got %v, want %v", got.KeepMajor, tt.wantKeepMajor)
+			case *got.KeepMajor != *tt.wantKeepMajor:
+				t.Errorf("KeepMajor: got %v, want %v", *got.KeepMajor, *tt.wantKeepMajor)
 			}
 		})
 	}

--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -30,13 +30,17 @@ type GitService interface {
 // It first tries to get the latest version from releases, and if that fails
 // or returns empty, it falls back to getting the latest version from tags.
 func (c *Controller) getLatestVersion(ctx context.Context, logger *slog.Logger, owner, repo, currentVersion string, resolved *config.Resolved) (string, error) {
-	return c.getLatestVersionWithStable(ctx, logger, owner, repo, isStableVersion(currentVersion), resolved)
+	return c.getLatestVersionWithStable(ctx, logger, owner, repo, isStableVersion(currentVersion), currentVersion, resolved)
 }
 
 // getLatestVersionWithStable is the same as getLatestVersion but takes an
 // explicit isStable flag instead of inferring it from currentVersion. Used by
 // branch-to-tag, which has no semver-shaped currentVersion to infer from.
-func (c *Controller) getLatestVersionWithStable(ctx context.Context, logger *slog.Logger, owner, repo string, isStable bool, resolved *config.Resolved) (string, error) {
+//
+// majorRef is the version string used to derive the current major when
+// keep-major is in effect. When the caller does not have a semver-shaped
+// reference (branch-to-tag), passing "" disables the major filter.
+func (c *Controller) getLatestVersionWithStable(ctx context.Context, logger *slog.Logger, owner, repo string, isStable bool, majorRef string, resolved *config.Resolved) (string, error) {
 	// Calculate cutoff once for min-age filtering. Honors per-rule overrides
 	// via effectiveMinAge (CLI > rules > config).
 	var cutoff time.Time
@@ -44,14 +48,70 @@ func (c *Controller) getLatestVersionWithStable(ctx context.Context, logger *slo
 		cutoff = c.param.Now.AddDate(0, 0, -mAge)
 	}
 
-	lv, versions, err := c.getLatestVersionFromReleases(ctx, logger, owner, repo, isStable, cutoff)
+	// Resolve effective keep-major and parse the current major. If keep-major
+	// is requested but majorRef cannot be parsed, fall back to no constraint
+	// and warn so the user sees why.
+	var currentMajor *int64
+	if c.effectiveKeepMajor(resolved) {
+		m, ok := parseMajor(majorRef)
+		if ok {
+			currentMajor = &m
+		} else {
+			logger.Warn("keep-major: cannot parse current version comment as semver; falling back to no major constraint",
+				"version", majorRef)
+		}
+	}
+
+	lv, versions, err := c.getLatestVersionFromReleases(ctx, logger, owner, repo, isStable, cutoff, currentMajor)
 	if err != nil {
 		slogerr.WithError(logger, err).Debug("get the latest version from releases")
 	}
 	if lv != "" {
 		return lv, nil
 	}
-	return c.getLatestVersionFromTags(ctx, logger, owner, repo, isStable, cutoff, versions)
+	return c.getLatestVersionFromTags(ctx, logger, owner, repo, isStable, cutoff, versions, currentMajor)
+}
+
+// parseMajor extracts the major version from a semver-shaped string. Returns
+// the major and ok=true on success.
+func parseMajor(v string) (int64, bool) {
+	if v == "" {
+		return 0, false
+	}
+	cv, err := version.NewVersion(v)
+	if err != nil {
+		return 0, false
+	}
+	segs := cv.Segments64()
+	if len(segs) == 0 {
+		return 0, false
+	}
+	return segs[0], true
+}
+
+// skipMajorMismatch reports whether tag should be skipped because its major
+// version differs from currentMajor. When currentMajor is nil or the tag is
+// not parseable as semver, the candidate passes through unchanged.
+func skipMajorMismatch(logger *slog.Logger, currentMajor *int64, tag string) bool {
+	if currentMajor == nil {
+		return false
+	}
+	v, err := version.NewVersion(tag)
+	if err != nil {
+		return false
+	}
+	segs := v.Segments64()
+	if len(segs) == 0 {
+		return false
+	}
+	if segs[0] == *currentMajor {
+		return false
+	}
+	logger.Info("skip release: major version mismatch",
+		"tag", tag,
+		"current_major", *currentMajor,
+		"candidate_major", segs[0])
+	return true
 }
 
 func isStableVersion(v string) bool {
@@ -85,7 +145,8 @@ func compare(latestSemver *version.Version, latestVersion, tag string) (*version
 // getLatestVersionFromReleases finds the latest version from repository releases.
 // It retrieves releases from GitHub API and compares them to find the highest
 // version using semantic versioning when possible, falling back to string comparison.
-func (c *Controller) getLatestVersionFromReleases(ctx context.Context, logger *slog.Logger, owner, repo string, isStable bool, cutoff time.Time) (string, map[string]struct{}, error) {
+// When currentMajor is non-nil, releases whose major version differs are skipped.
+func (c *Controller) getLatestVersionFromReleases(ctx context.Context, logger *slog.Logger, owner, repo string, isStable bool, cutoff time.Time, currentMajor *int64) (string, map[string]struct{}, error) {
 	opts := &github.ListOptions{
 		PerPage: 30, //nolint:mnd
 	}
@@ -104,6 +165,10 @@ func (c *Controller) getLatestVersionFromReleases(ctx context.Context, logger *s
 		}
 		tag := release.GetTagName()
 		versions[tag] = struct{}{}
+		// Skip releases with a major-version mismatch when keep-major is set
+		if skipMajorMismatch(logger, currentMajor, tag) {
+			continue
+		}
 		// Skip releases within cooldown period
 		if !cutoff.IsZero() && release.GetPublishedAt().After(cutoff) {
 			logger.Info("skip release due to cooldown",
@@ -150,7 +215,8 @@ func checkTagCooldown(ctx context.Context, logger *slog.Logger, gitService GitSe
 // It retrieves tags from GitHub API and compares them to find the highest
 // version using semantic versioning when possible, falling back to string comparison.
 // It filters out prerelease versions when currentVersion is stable.
-func (c *Controller) getLatestVersionFromTags(ctx context.Context, logger *slog.Logger, owner, repo string, isStable bool, cutoff time.Time, releaseVersions map[string]struct{}) (string, error) {
+// When currentMajor is non-nil, tags whose major version differs are skipped.
+func (c *Controller) getLatestVersionFromTags(ctx context.Context, logger *slog.Logger, owner, repo string, isStable bool, cutoff time.Time, releaseVersions map[string]struct{}, currentMajor *int64) (string, error) {
 	opts := &github.ListOptions{
 		PerPage: 30, //nolint:mnd
 	}
@@ -173,6 +239,11 @@ func (c *Controller) getLatestVersionFromTags(ctx context.Context, logger *slog.
 			if tv, err := version.NewVersion(t); err == nil && tv.Prerelease() != "" {
 				continue
 			}
+		}
+
+		// Skip tags with a major-version mismatch when keep-major is set
+		if skipMajorMismatch(logger, currentMajor, t) {
+			continue
 		}
 
 		// Skip tags within cooldown period

--- a/pkg/controller/run/github_internal_test.go
+++ b/pkg/controller/run/github_internal_test.go
@@ -516,6 +516,117 @@ func Test_checkTagCooldown(t *testing.T) { //nolint:funlen
 	}
 }
 
+func Test_parseMajor(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		version string
+		want    int64
+		wantOK  bool
+	}{
+		{name: "empty string", version: "", want: 0, wantOK: false},
+		{name: "semver with v prefix", version: "v4.3.1", want: 4, wantOK: true},
+		{name: "semver without v prefix", version: "5.0.0", want: 5, wantOK: true},
+		{name: "short major", version: "v3", want: 3, wantOK: true},
+		{name: "prerelease", version: "v6.0.0-rc.1", want: 6, wantOK: true},
+		{name: "branch name", version: "main", want: 0, wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseMajor(tt.version)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && got != tt.want {
+				t.Errorf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_skipMajorMismatch(t *testing.T) {
+	t.Parallel()
+	four := int64(4)
+	tests := []struct {
+		name         string
+		currentMajor *int64
+		tag          string
+		want         bool
+	}{
+		{name: "nil currentMajor lets every tag pass", currentMajor: nil, tag: "v9.0.0", want: false},
+		{name: "matching major passes", currentMajor: &four, tag: "v4.3.1", want: false},
+		{name: "different major is skipped", currentMajor: &four, tag: "v5.0.0", want: true},
+		{name: "non-semver tag passes (cannot judge)", currentMajor: &four, tag: "release", want: false},
+	}
+	logger := slog.New(slog.DiscardHandler)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := skipMajorMismatch(logger, tt.currentMajor, tt.tag)
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestController_getLatestVersionFromReleases_keepMajor verifies that
+// providing a non-nil currentMajor filters out releases whose major version
+// differs, so the latest candidate stays within the current major series.
+func TestController_getLatestVersionFromReleases_keepMajor(t *testing.T) {
+	t.Parallel()
+	four := int64(4)
+	releases := []*github.RepositoryRelease{
+		{TagName: new("v6.0.2")},
+		{TagName: new("v5.1.0")},
+		{TagName: new("v4.3.1")},
+		{TagName: new("v4.2.0")},
+		{TagName: new("v3.5.0")},
+	}
+	mockRepo := &mockRepoService{
+		listReleasesFunc: func(_ context.Context, _, _ string, _ *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error) {
+			return releases, nil, nil
+		},
+	}
+	c := &Controller{repositoriesService: newTestRepoService(mockRepo)}
+	logger := slog.New(slog.DiscardHandler)
+	got, _, err := c.getLatestVersionFromReleases(t.Context(), logger, "owner", "repo", true, time.Time{}, &four)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "v4.3.1" {
+		t.Errorf("got %q, want v4.3.1", got)
+	}
+}
+
+// TestController_getLatestVersionFromTags_keepMajor verifies the same
+// major-version filter for the tag-based search path.
+func TestController_getLatestVersionFromTags_keepMajor(t *testing.T) {
+	t.Parallel()
+	four := int64(4)
+	tags := []*github.RepositoryTag{
+		{Name: new("v6.0.2")},
+		{Name: new("v5.0.0")},
+		{Name: new("v4.3.1")},
+		{Name: new("v4.0.0")},
+	}
+	mockRepo := &mockRepoService{
+		listTagsFunc: func(_ context.Context, _, _ string, _ *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error) {
+			return tags, nil, nil
+		},
+	}
+	c := &Controller{repositoriesService: newTestRepoService(mockRepo)}
+	logger := slog.New(slog.DiscardHandler)
+	got, err := c.getLatestVersionFromTags(t.Context(), logger, "owner", "repo", false, time.Time{}, nil, &four)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "v4.3.1" {
+		t.Errorf("got %q, want v4.3.1", got)
+	}
+}
+
 type mockGitService struct {
 	getCommitFunc func(ctx context.Context, owner, repo, sha string) (*github.Commit, *github.Response, error)
 }

--- a/pkg/controller/run/github_internal_test.go
+++ b/pkg/controller/run/github_internal_test.go
@@ -339,7 +339,7 @@ func TestController_getLatestVersionFromReleases(t *testing.T) { //nolint:funlen
 			ctx := t.Context()
 			logger := slog.New(slog.DiscardHandler)
 
-			gotVersion, _, err := c.getLatestVersionFromReleases(ctx, logger, "owner", "repo", tt.isStable, time.Time{})
+			gotVersion, _, err := c.getLatestVersionFromReleases(ctx, logger, "owner", "repo", tt.isStable, time.Time{}, nil)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getLatestVersionFromReleases() error = %v, wantErr %v", err, tt.wantErr)
@@ -670,7 +670,7 @@ func TestController_getLatestVersionFromTags(t *testing.T) { //nolint:funlen
 			ctx := t.Context()
 			logger := slog.New(slog.DiscardHandler)
 
-			gotVersion, err := c.getLatestVersionFromTags(ctx, logger, "owner", "repo", false, time.Time{}, nil)
+			gotVersion, err := c.getLatestVersionFromTags(ctx, logger, "owner", "repo", false, time.Time{}, nil, nil)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getLatestVersionFromTags() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -213,6 +213,25 @@ func (c *Controller) minAgeFallback() int {
 	return 0
 }
 
+// effectiveKeepMajor resolves the keep-major setting for a single action using
+// the precedence: rules > CLI flag > config.keep_major > default false.
+//
+// rules take the highest precedence so that per-action overrides (including
+// explicit opt-outs via keep_major: false) work even when the user passes
+// --keep-major on the CLI.
+func (c *Controller) effectiveKeepMajor(resolved *config.Resolved) bool {
+	if resolved != nil && resolved.KeepMajor != nil {
+		return *resolved.KeepMajor
+	}
+	if c.param.KeepMajor {
+		return true
+	}
+	if c.cfg.KeepMajor != nil {
+		return *c.cfg.KeepMajor
+	}
+	return false
+}
+
 // finalPinnedSHA returns the commit SHA that the action will resolve to after
 // pinact runs, or "" if no SHA is involved (e.g., an unpinnable branch that
 // will surface as ErrCantPinned elsewhere). If parseLine produced a patched
@@ -473,12 +492,14 @@ func (c *Controller) matchBranchToTag(v string) bool {
 // the line to its commit SHA. Falls back to including pre-releases only when
 // no stable tag exists.
 func (c *Controller) convertBranchToLatestTag(ctx context.Context, logger *slog.Logger, action *Action, resolved *config.Resolved) (string, error) {
-	lv, err := c.getLatestVersionWithStable(ctx, logger, action.RepoOwner, action.RepoName, true, resolved)
+	// branch-to-tag has no semver-shaped current version; pass "" so the
+	// keep-major filter is disabled for this path.
+	lv, err := c.getLatestVersionWithStable(ctx, logger, action.RepoOwner, action.RepoName, true, "", resolved)
 	if err != nil {
 		return "", fmt.Errorf("get the latest stable version: %w", err)
 	}
 	if lv == "" {
-		lv, err = c.getLatestVersionWithStable(ctx, logger, action.RepoOwner, action.RepoName, false, resolved)
+		lv, err = c.getLatestVersionWithStable(ctx, logger, action.RepoOwner, action.RepoName, false, "", resolved)
 		if err != nil {
 			return "", fmt.Errorf("get the latest version: %w", err)
 		}

--- a/pkg/controller/run/parse_line_internal_test.go
+++ b/pkg/controller/run/parse_line_internal_test.go
@@ -1353,6 +1353,152 @@ func TestController_effectiveMinAge(t *testing.T) {
 	}
 }
 
+// TestController_effectiveKeepMajor verifies the rules > CLI > config
+// precedence for the per-action keep-major decision. Rules win over the CLI
+// so an explicit per-action opt-out (rules[].keep_major: false) is honored
+// even when the user passes --keep-major globally.
+func TestController_effectiveKeepMajor(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		cliKeepMajor  bool
+		cfgKeepMajor  *bool
+		ruleKeepMajor *bool
+		want          bool
+	}{
+		{name: "default false when nothing is set", cliKeepMajor: false, cfgKeepMajor: nil, ruleKeepMajor: nil, want: false},
+		{name: "CLI true with no rule and no cfg", cliKeepMajor: true, cfgKeepMajor: nil, ruleKeepMajor: nil, want: true},
+		{name: "cfg true with no CLI and no rule", cliKeepMajor: false, cfgKeepMajor: new(true), ruleKeepMajor: nil, want: true},
+		{name: "rule true overrides cfg/CLI false", cliKeepMajor: false, cfgKeepMajor: new(false), ruleKeepMajor: new(true), want: true},
+		{name: "rule false overrides CLI true (per-action opt-out)", cliKeepMajor: true, cfgKeepMajor: nil, ruleKeepMajor: new(false), want: false},
+		{name: "rule false overrides cfg true (per-action opt-out)", cliKeepMajor: false, cfgKeepMajor: new(true), ruleKeepMajor: new(false), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := &Controller{
+				cfg:   &config.Config{KeepMajor: tt.cfgKeepMajor},
+				param: &ParamRun{KeepMajor: tt.cliKeepMajor},
+			}
+			got := ctrl.effectiveKeepMajor(&config.Resolved{KeepMajor: tt.ruleKeepMajor})
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestController_parseLine_update_keepMajor verifies that --keep-major
+// restricts -u to releases within the same major version as the current pin's
+// version comment. The repository advertises v6.0.0 as the latest, but the
+// action is pinned at v4.3.1 so the upgrade target must stay at v4.x.
+func TestController_parseLine_update_keepMajor(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC)
+	tags := &github.ListTagsResult{
+		Tags: []*github.RepositoryTag{
+			{Name: new("v6.0.0"), Commit: &github.Commit{SHA: new("6666666666666666666666666666666666666666")}},
+			{Name: new("v4.4.0"), Commit: &github.Commit{SHA: new("4444444444444444444444444444444444444444")}},
+			{Name: new("v4.3.1"), Commit: &github.Commit{SHA: new("3333333333333333333333333333333333333333")}},
+		},
+		Response: &github.Response{},
+	}
+	releases := &github.ListReleasesResult{
+		Releases: []*github.RepositoryRelease{
+			{TagName: new("v6.0.0"), PublishedAt: &github.Timestamp{Time: now.AddDate(0, 0, -10)}},
+			{TagName: new("v4.4.0"), PublishedAt: &github.Timestamp{Time: now.AddDate(0, 0, -20)}},
+			{TagName: new("v4.3.1"), PublishedAt: &github.Timestamp{Time: now.AddDate(0, 0, -90)}},
+		},
+		Response: &github.Response{},
+	}
+	commits := map[string]*github.GetCommitSHA1Result{
+		"aquaproj/example/v4.4.0": {SHA: "4444444444444444444444444444444444444444"},
+	}
+	cfg := &config.Config{Separator: " # "}
+	fs := afero.NewMemMapFs()
+	ctrl := New(&github.RepositoriesServiceImpl{
+		Tags:     map[string]*github.ListTagsResult{"aquaproj/example/0": tags},
+		Releases: map[string]*github.ListReleasesResult{"aquaproj/example/0": releases},
+		Commits:  commits,
+	}, nil, fs, cfg, &ParamRun{
+		Update:    true,
+		KeepMajor: true,
+		Now:       now,
+	})
+	logger := slog.New(slog.DiscardHandler)
+
+	line := "  - uses: aquaproj/example@3333333333333333333333333333333333333333 # v4.3.1"
+	got, err := ctrl.parseLine(t.Context(), logger, line)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "  - uses: aquaproj/example@4444444444444444444444444444444444444444 # v4.4.0"
+	if got != want {
+		t.Fatalf("--keep-major must keep the upgrade within v4.x:\n  want %s\n  got  %s", want, got)
+	}
+}
+
+// TestController_parseLine_update_ruleKeepMajor verifies that a per-action
+// rules[].keep_major override takes effect even when the global config and
+// CLI both leave keep-major off. Without the rule, -u would jump to v6.0.0.
+func TestController_parseLine_update_ruleKeepMajor(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC)
+	tags := &github.ListTagsResult{
+		Tags: []*github.RepositoryTag{
+			{Name: new("v6.0.0"), Commit: &github.Commit{SHA: new("6666666666666666666666666666666666666666")}},
+			{Name: new("v4.4.0"), Commit: &github.Commit{SHA: new("4444444444444444444444444444444444444444")}},
+		},
+		Response: &github.Response{},
+	}
+	releases := &github.ListReleasesResult{
+		Releases: []*github.RepositoryRelease{
+			{TagName: new("v6.0.0"), PublishedAt: &github.Timestamp{Time: now.AddDate(0, 0, -10)}},
+			{TagName: new("v4.4.0"), PublishedAt: &github.Timestamp{Time: now.AddDate(0, 0, -20)}},
+		},
+		Response: &github.Response{},
+	}
+	commits := map[string]*github.GetCommitSHA1Result{
+		"aquaproj/example/v4.4.0": {SHA: "4444444444444444444444444444444444444444"},
+	}
+	cfg := &config.Config{
+		Separator: " # ",
+		Rules: []*config.Rule{
+			{
+				KeepMajor: new(true),
+				Conditions: []*config.Condition{
+					{Expr: `ActionRepoOwner == "aquaproj"`},
+				},
+			},
+		},
+	}
+	for i, r := range cfg.Rules {
+		if err := r.Init(); err != nil {
+			t.Fatalf("init rules[%d]: %v", i, err)
+		}
+	}
+	fs := afero.NewMemMapFs()
+	ctrl := New(&github.RepositoriesServiceImpl{
+		Tags:     map[string]*github.ListTagsResult{"aquaproj/example/0": tags},
+		Releases: map[string]*github.ListReleasesResult{"aquaproj/example/0": releases},
+		Commits:  commits,
+	}, nil, fs, cfg, &ParamRun{
+		Update: true,
+		Now:    now,
+	})
+	logger := slog.New(slog.DiscardHandler)
+
+	line := "  - uses: aquaproj/example@3333333333333333333333333333333333333333 # v4.3.1"
+	got, err := ctrl.parseLine(t.Context(), logger, line)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "  - uses: aquaproj/example@4444444444444444444444444444444444444444 # v4.4.0"
+	if got != want {
+		t.Fatalf("rules[].keep_major=true must keep the upgrade within v4.x:\n  want %s\n  got  %s", want, got)
+	}
+}
+
 // TestController_minAgeFallback verifies the CLI/env > config.min_age.value
 // precedence used by contexts without rule resolution (the -update cooldown
 // filter inside getLatestVersionWithStable).

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -27,6 +27,7 @@ type ParamRun struct {
 	IsGitHubActions   bool
 	Fix               bool
 	NoAPI             bool
+	KeepMajor         bool
 	Stderr            io.Writer
 	Stdout            io.Writer
 	Includes          []*regexp.Regexp

--- a/pkg/di/flag.go
+++ b/pkg/di/flag.go
@@ -39,6 +39,7 @@ type Flags struct {
 
 	FixCount    int
 	MinAge      int
+	KeepMajor   bool
 	Include     []string
 	Exclude     []string
 	BranchToTag []string

--- a/pkg/di/run.go
+++ b/pkg/di/run.go
@@ -180,6 +180,7 @@ func buildParam(flags *Flags) (*run.ParamRun, error) {
 		Excludes:          excludes,
 		BranchToTags:      branchToTags,
 		MinAge:            flags.MinAge,
+		KeepMajor:         flags.KeepMajor,
 		Now:               time.Now(),
 		Format:            flags.Format,
 	}


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: #1561
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

<!-- Please write the description here -->
## Summary

Closes #1561.

Adds an opt-in `--keep-major` CLI flag and `keep_major` yaml setting that constrain `pinact run -u` to releases within the same major version as the current pin's version comment. Default is `false` everywhere, so existing behavior is fully preserved.

Per-action overrides are supported via `rules[].keep_major` (`true` to opt in for specific actions, `false` to opt out when a global `keep_major: true` is set).

### Example

```yaml
# .pinact.yaml
keep_major: true

rules:
  # Always take the absolute latest for this action.
  - keep_major: false
    conditions:
      - expr: ActionRepoFullName == "anthropics/claude-code-action"
```

```console
$ pinact run -u --keep-major
```

For an action pinned at `v4.3.1`, the upgrade target is restricted to `v4.x.y`; a published `v5.0.0` (or higher) is skipped with an INFO log explaining the major mismatch.

## Implementation

- `pkg/config`: `Config.KeepMajor`, `Rule.KeepMajor`, `Resolved.KeepMajor` (all `*bool` so unset is distinguishable from explicit `false`); merged in `ResolveRules` and `mergeConfig` next to the existing `min_age` logic.
- `pkg/controller/run/github.go`: a `currentMajor *int64` parameter added to `getLatestVersionFromReleases` / `getLatestVersionFromTags`. When non-nil, candidates whose major differs are skipped before the existing comparison. Small helpers `parseMajor` and `skipMajorMismatch` are reused across both call sites.
- `pkg/controller/run/parse_line.go`: `effectiveKeepMajor` resolves the per-action value with precedence **rules > CLI > config > default false**. `convertBranchToLatestTag` explicitly passes `""` for the major reference, disabling the filter on that path (no semver-shaped current version to anchor on).
- If the existing version comment cannot be parsed as semver, pinact warns and falls back to the unconstrained behavior so the run still upgrades — matching the semantics in the issue.

## Notes for review

- I placed the yaml key at the top level (`keep_major: true`) instead of the nested `update.keep_major` shown in the issue's example, because the existing `min_age` setting also lives at the top level and `keep_major` felt like a sibling of it rather than a child of a new `update` block. Happy to move it under `update.keep_major` if you'd prefer that grouping for a future "things that only affect `-u`" namespace.
- Precedence ended up as **rules > CLI > config > default**. The issue says "CLI flag overrides yaml; per-action rule overrides both" — same outcome, just stated with the rule first.

## Test plan

- [x] `cmdx v` (go vet) — clean
- [x] `cmdx t` (`go test ./... -race -covermode=atomic`) — green; coverage `pkg/config` 86.7%, `pkg/controller/run` 75.7%
- [x] `go build ./...` — clean
- [x] `pinact run --help` shows `--keep-major`
- [x] Regenerated JSON schema matches the hand-checked file
- [ ] `cmdx l` (golangci-lint) — not run locally; relying on CI

### New tests added

- `pkg/config/config_internal_test.go`: `ResolveRules` cases for `rules[].keep_major` (true / false / later-rule-wins).
- `pkg/controller/run/github_internal_test.go`: unit tests for `parseMajor` and `skipMajorMismatch`; mocked-API filter tests for `getLatestVersionFromReleases` / `getLatestVersionFromTags`.
- `pkg/controller/run/parse_line_internal_test.go`: `effectiveKeepMajor` precedence table; end-to-end `parseLine` tests verifying that both `--keep-major` and `rules[].keep_major: true` keep the upgrade within `v4.x` when `v6.0.0` is the latest release.