### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,9 +5,11 @@ permissions: {}
 jobs:
   autofix:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write
     timeout-minutes: 15
     steps:
-      - uses: suzuki-shunsuke/go-autofix-action@ba716cebb7767055bdde0e62bb91d715bde39ab2 # v0.1.12
+      - uses: suzuki-shunsuke/go-autofix-action@9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13
         with:
           aqua_version: v2.59.1
+          takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ jobs:
     with:
       go-version-file: go.mod
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,9 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write

--- a/.github/workflows/workflow_call_integration_test.yaml
+++ b/.github/workflows/workflow_call_integration_test.yaml
@@ -1,11 +1,17 @@
 ---
 name: integration test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 
 jobs:
   integration-test:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write
+      contents: read
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -15,6 +21,11 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
           aqua_version: v2.59.1

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -12,6 +12,7 @@ jobs:
     secrets:
       TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
+      contents: read
       id-token: write
 
   test:

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,17 +1,27 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   integration-test:
     uses: ./.github/workflows/workflow_call_integration_test.yaml
-    permissions: {}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+    permissions:
+      id-token: write
 
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
       golangci-lint-timeout: 120s
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write


### PR DESCRIPTION
Introduce Takumi Guard (Go variant) into the CI/CD workflows to harden module downloads and release/autofix jobs.

## Changes

- `.github/workflows/release.yaml`
  - Added `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to the `release` job (calls go-release-workflow `# v8.1.0`).

- `.github/workflows/test.yaml` (entrypoint)
  - Added `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to the `test` job (local call of `workflow_call_test.yaml`).
  - Added `id-token: write` to that job's permissions.

- `.github/workflows/workflow_call_test.yaml` (reusable, `workflow_call`)
  - Declared required secret `TAKUMI_GUARD_BOT_ID` under `on.workflow_call.secrets`.
  - Bumped go-test-full-workflow ref `e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2` → `98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0`.
  - Added `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to both the `integration-test` and `test` jobs.
  - Added `id-token: write` to both jobs' permissions.

- `.github/workflows/workflow_call_integration_test.yaml` (reusable, `workflow_call`, runs Go directly)
  - Declared required secret `TAKUMI_GUARD_BOT_ID` under `on.workflow_call.secrets`.
  - Added `id-token: write` and `contents: read` to the `integration-test` job permissions.
  - Inserted setup step `flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1` right after `actions/setup-go` and before `aqua-installer`.

- `.github/workflows/autofix.yaml`
  - Bumped go-autofix-action ref `ba716cebb7767055bdde0e62bb91d715bde39ab2 # v0.1.12` → `9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13`.
  - Added `takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}` input.
  - Added `id-token: write` to the `autofix` job permissions.

## Note

- go-test-full-workflow was bumped across a MAJOR version (v5 → v6).

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository (or organization) for these workflows to run successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)