### PR TITLE
add skip-immutable flag to skip pinning action versions with immutable GitHub release

### DIFF
--- a/pkg/cli/run/command.go
+++ b/pkg/cli/run/command.go
@@ -104,6 +104,12 @@ $ pinact run .github/actions/foo/action.yaml .github/actions/bar/action.yaml
 				Destination: &flags.NoAPI,
 			},
 			&cli.BoolFlag{
+				Name:        "skip-immutable",
+				Usage:       "Skip pinning actions whose version tags correspond to immutable GitHub releases",
+				Destination: &flags.SkipImmutable,
+				Sources:     cli.EnvVars("PINACT_SKIP_IMMUTABLE"),
+			},
+			&cli.BoolFlag{
 				Name:        "check",
 				Usage:       "Alias for -fix=false. For offline check use -fix=false -no-api",
 				Destination: &flags.Check,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,13 +31,14 @@ const (
 )
 
 type Config struct {
-	Version       int             `json:"version,omitempty" jsonschema:"enum=2,enum=3"`
-	Files         []*File         `json:"files,omitempty" jsonschema:"description=Target files. If files are passed via positional command line arguments, this is ignored"`
-	IgnoreActions []*IgnoreAction `json:"ignore_actions,omitempty" yaml:"ignore_actions" jsonschema:"description=Actions and reusable workflows that pinact ignores. For new configurations consider using 'rules' with 'ignore: true' for more flexibility"`
-	GHES          *GHES           `json:"ghes,omitempty" yaml:"ghes" jsonschema:"description=GitHub Enterprise Server configuration"`
-	Separator     string          `json:"separator,omitempty" jsonschema:"description=Separator between version and tag comment. Default is ' # '"`
-	MinAge        *MinAge         `json:"min_age,omitzero" yaml:"min_age" jsonschema:"description=Default min-age settings. value is the threshold in days; always opts every run into the passive audit. rules can override value per action"`
-	Rules         []*Rule         `json:"rules,omitempty" jsonschema:"description=Per-action setting overrides. Later matching rules override earlier ones at the field level"`
+	Version        int             `json:"version,omitempty" jsonschema:"enum=2,enum=3"`
+	Files          []*File         `json:"files,omitempty" jsonschema:"description=Target files. If files are passed via positional command line arguments, this is ignored"`
+	IgnoreActions  []*IgnoreAction `json:"ignore_actions,omitempty" yaml:"ignore_actions" jsonschema:"description=Actions and reusable workflows that pinact ignores. For new configurations consider using 'rules' with 'ignore: true' for more flexibility"`
+	GHES           *GHES           `json:"ghes,omitempty" yaml:"ghes" jsonschema:"description=GitHub Enterprise Server configuration"`
+	Separator      string          `json:"separator,omitempty" jsonschema:"description=Separator between version and tag comment. Default is ' # '"`
+	MinAge         *MinAge         `json:"min_age,omitzero" yaml:"min_age" jsonschema:"description=Default min-age settings. value is the threshold in days; always opts every run into the passive audit. rules can override value per action"`
+	SkipImmutable  bool            `json:"skip_immutable,omitempty" yaml:"skip_immutable" jsonschema:"description=Skip pinning actions whose version tags correspond to immutable GitHub releases"`
+	Rules          []*Rule         `json:"rules,omitempty" jsonschema:"description=Per-action setting overrides. Later matching rules override earlier ones at the field level"`
 }
 
 // MinAge controls both the threshold and whether the passive audit auto-runs.

--- a/pkg/controller/run/github.go
+++ b/pkg/controller/run/github.go
@@ -18,6 +18,7 @@ type RepositoriesService interface {
 	ListTags(ctx context.Context, logger *slog.Logger, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryTag, *github.Response, error)
 	ListReleases(ctx context.Context, logger *slog.Logger, owner, repo string, opts *github.ListOptions) ([]*github.RepositoryRelease, *github.Response, error)
 	GetCommitSHA1(ctx context.Context, logger *slog.Logger, owner, repo, ref, lastSHA string) (string, *github.Response, error)
+	GetReleaseByTag(ctx context.Context, logger *slog.Logger, owner, repo, tag string) (*github.RepositoryRelease, *github.Response, error)
 }
 
 // GitService defines the interface for GitHub Git API operations

--- a/pkg/controller/run/github_internal_test.go
+++ b/pkg/controller/run/github_internal_test.go
@@ -182,13 +182,18 @@ func (m *mockRepoService) Get(_ context.Context, _, _ string) (*github.Repositor
 	return nil, nil, nil
 }
 
+func (m *mockRepoService) GetReleaseByTag(_ context.Context, _, _, _ string) (*github.RepositoryRelease, *github.Response, error) {
+	return nil, nil, errors.New("not implemented")
+}
+
 // newTestRepoService creates a RepositoriesServiceImpl with the given mock for testing
 func newTestRepoService(mock *mockRepoService) *github.RepositoriesServiceImpl {
 	resolver := github.NewClientResolver(mock, nil, nil, nil, false)
 	impl := &github.RepositoriesServiceImpl{
-		Tags:     map[string]*github.ListTagsResult{},
-		Releases: map[string]*github.ListReleasesResult{},
-		Commits:  map[string]*github.GetCommitSHA1Result{},
+		Tags:          map[string]*github.ListTagsResult{},
+		Releases:      map[string]*github.ListReleasesResult{},
+		Commits:       map[string]*github.GetCommitSHA1Result{},
+		ReleasesByTag: map[string]*github.GetReleaseByTagResult{},
 	}
 	impl.SetResolver(resolver)
 	return impl

--- a/pkg/controller/run/parse_line.go
+++ b/pkg/controller/run/parse_line.go
@@ -382,6 +382,14 @@ func (c *Controller) processPinnedShortsemverComment(ctx context.Context, logger
 // semver tag. These are unpinned and must be pinned to a commit SHA, or
 // updated to the latest version when --update is set.
 func (c *Controller) processTaggedVersion(ctx context.Context, logger *slog.Logger, action *Action, resolved *config.Resolved) (string, error) {
+	// Skip pinning if the tag corresponds to an immutable release.
+	if c.param.SkipImmutable {
+		if c.isImmutableRelease(ctx, logger, action.RepoOwner, action.RepoName, action.Version) {
+			logger.Debug("skip pinning: tag is an immutable release", "tag", action.Version)
+			return "", nil
+		}
+	}
+
 	typ := getVersionType(action.Version)
 	switch getVersionType(action.VersionComment) {
 	case Empty:
@@ -699,4 +707,16 @@ func (c *Controller) verify(ctx context.Context, logger *slog.Logger, action *Ac
 		"commit_hash_of_version_annotation", sha,
 		"docs", "https://github.com/suzuki-shunsuke/pinact/blob/main/docs/codes/001.md",
 	)
+}
+
+// isImmutableRelease checks whether a tag corresponds to an immutable GitHub release.
+// It calls the GitHub API to get the release by tag and checks the Immutable field.
+// Returns false if the release is not found or an error occurs (fails open).
+func (c *Controller) isImmutableRelease(ctx context.Context, logger *slog.Logger, owner, repo, tag string) bool {
+	release, _, err := c.repositoriesService.GetReleaseByTag(ctx, logger, owner, repo, tag)
+	if err != nil {
+		logger.Debug("failed to get release by tag for immutable check", "tag", tag, "error", err)
+		return false
+	}
+	return release.GetImmutable()
 }

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -27,6 +27,7 @@ type ParamRun struct {
 	IsGitHubActions   bool
 	Fix               bool
 	NoAPI             bool
+	SkipImmutable     bool
 	Stderr            io.Writer
 	Stdout            io.Writer
 	Includes          []*regexp.Regexp

--- a/pkg/di/flag.go
+++ b/pkg/di/flag.go
@@ -18,12 +18,13 @@ type Flags struct {
 
 	// -check and -diff are silent aliases for -fix=false in v4. They keep
 	// their own destinations so buildParam can translate them.
-	Check     bool
-	Diff      bool
-	Update    bool
-	Fix       bool
-	Format    string
-	Separator string
+	Check         bool
+	Diff          bool
+	Update        bool
+	Fix           bool
+	SkipImmutable bool
+	Format        string
+	Separator     string
 
 	IsGitHubActions bool
 	FallbackEnabled bool

--- a/pkg/di/ghes.go
+++ b/pkg/di/ghes.go
@@ -46,9 +46,10 @@ func setupGHESServices(ctx context.Context, gh *github.Client, cfg *config.Confi
 	)
 
 	repoService := &github.RepositoriesServiceImpl{
-		Tags:     map[string]*github.ListTagsResult{},
-		Releases: map[string]*github.ListReleasesResult{},
-		Commits:  map[string]*github.GetCommitSHA1Result{},
+		Tags:          map[string]*github.ListTagsResult{},
+		Releases:      map[string]*github.ListReleasesResult{},
+		Commits:       map[string]*github.GetCommitSHA1Result{},
+		ReleasesByTag: map[string]*github.GetReleaseByTagResult{},
 	}
 	repoService.SetResolver(resolver)
 

--- a/pkg/di/run.go
+++ b/pkg/di/run.go
@@ -59,6 +59,10 @@ func Run(ctx context.Context, logger *slogutil.Logger, flags *Flags, secrets *Se
 	if err != nil {
 		return err
 	}
+	// Merge config's skip_immutable when the CLI flag was not explicitly set.
+	if !param.SkipImmutable && cfg.SkipImmutable {
+		param.SkipImmutable = true
+	}
 	if flags.DiffFile != "" {
 		df, err := loadDiffFilter(flags.DiffFile, os.Stdin)
 		if err != nil {
@@ -174,6 +178,7 @@ func buildParam(flags *Flags) (*run.ParamRun, error) {
 		NoAPI:             flags.NoAPI,
 		Fix:               resolveFix(flags),
 		IsGitHubActions:   flags.IsGitHubActions,
+		SkipImmutable:     flags.SkipImmutable,
 		Stderr:            os.Stderr,
 		Stdout:            os.Stdout,
 		Includes:          includes,

--- a/pkg/github/service.go
+++ b/pkg/github/service.go
@@ -12,6 +12,7 @@ type RepositoriesService interface {
 	ListTags(ctx context.Context, owner string, repo string, opts *ListOptions) ([]*RepositoryTag, *Response, error)
 	GetCommitSHA1(ctx context.Context, owner, repo, ref, lastSHA string) (string, *Response, error)
 	ListReleases(ctx context.Context, owner, repo string, opts *ListOptions) ([]*RepositoryRelease, *Response, error)
+	GetReleaseByTag(ctx context.Context, owner, repo, tag string) (*RepositoryRelease, *Response, error)
 	Get(ctx context.Context, owner, repo string) (*Repository, *Response, error)
 }
 
@@ -189,12 +190,20 @@ type ListReleasesResult struct {
 	err      error
 }
 
+// GetReleaseByTagResult holds the cached result of a GetReleaseByTag call.
+type GetReleaseByTagResult struct {
+	Release  *RepositoryRelease
+	Response *Response
+	err      error
+}
+
 // RepositoriesServiceImpl wraps a RepositoriesService with caching and GHES fallback support.
 type RepositoriesServiceImpl struct {
-	resolver *ClientResolver
-	Tags     map[string]*ListTagsResult
-	Commits  map[string]*GetCommitSHA1Result
-	Releases map[string]*ListReleasesResult
+	resolver       *ClientResolver
+	Tags           map[string]*ListTagsResult
+	Commits        map[string]*GetCommitSHA1Result
+	Releases       map[string]*ListReleasesResult
+	ReleasesByTag  map[string]*GetReleaseByTagResult
 }
 
 // SetResolver sets the ClientResolver for the RepositoriesServiceImpl.
@@ -265,6 +274,31 @@ func (r *RepositoriesServiceImpl) ListReleases(ctx context.Context, logger *slog
 		err:      err,
 	}
 	return arr, resp, err
+}
+
+// GetReleaseByTag retrieves a release by tag name with caching and GHES fallback.
+func (r *RepositoriesServiceImpl) GetReleaseByTag(ctx context.Context, logger *slog.Logger, owner, repo, tag string) (*RepositoryRelease, *Response, error) {
+	key := fmt.Sprintf("%s/%s/%s", owner, repo, tag)
+	if result, ok := r.ReleasesByTag[key]; ok {
+		return result.Release, result.Response, result.err
+	}
+
+	release, resp, err := r.getReleaseByTag(ctx, logger, owner, repo, tag)
+	r.ReleasesByTag[key] = &GetReleaseByTagResult{
+		Release:  release,
+		Response: resp,
+		err:      err,
+	}
+	return release, resp, err
+}
+
+// getReleaseByTag calls the appropriate RepositoriesService based on the repository host.
+func (r *RepositoriesServiceImpl) getReleaseByTag(ctx context.Context, logger *slog.Logger, owner, repo, tag string) (*RepositoryRelease, *Response, error) {
+	service, err := r.resolver.GetRepositoriesService(ctx, logger, owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	return service.GetReleaseByTag(ctx, owner, repo, tag) //nolint:wrapcheck
 }
 
 // getCommitSHA1 calls the appropriate RepositoriesService based on the repository host.


### PR DESCRIPTION
## Check List

- [X] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/suzuki-shunsuke/pinact/issues/1211
- [X] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

## Description

When `--skip-immutable` is enabled, pinact checks whether an action's version tag corresponds to an immutable GitHub release before pinning it to a commit SHA. 

### Changes
- Added GetReleaseByTag to RepositoriesService interface (with caching in RepositoriesServiceImpl)
- Added skip_immutable config option and --skip-immutable CLI flag (PINACT_SKIP_IMMUTABLE env var)
- Added immutable check in processTaggedVersion before pinning
- Regenerated JSON schema