### PR TITLE
test: update testdata for actions/checkout v2.8.0 and v3.7.0

### DIFF
--- a/testdata/foo_after.yaml
+++ b/testdata/foo_after.yaml
@@ -11,14 +11,14 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  #  v3.5.3
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  #  tag=v3.5.3
       - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
-      -   uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      -   uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+      - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
       - uses: actions/setup-java@v3
       - uses: rharkor/caching-for-turbo@c3de885e542eec7eb01eb1a6a59e97c7a2448615 # v1.6
       - uses: peaceiris/actions-gh-pages@v4.0.0
-      - 'uses': "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744" # v3.6.0
-      - "uses": 'actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744' # v3.6.0
+      - 'uses': "actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26" # v3.7.0
+      - "uses": 'actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26' # v3.7.0
       - uses: cardinalby/git-get-release-action@cf4593dd18e51a1ecfbfb1c68abac9910a8b1e0c # v1
   actionlint:
     uses: suzuki-shunsuke/actionlint-workflow/.github/workflows/actionlint.yaml@b6a5f966d4504893b2aeb60cf2b0de8946e48504 # v0.5.0

--- a/testdata/foo_include_after.yaml
+++ b/testdata/foo_include_after.yaml
@@ -11,14 +11,14 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  #  v3.5.3
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  #  tag=v3.5.3
       - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
-      -   uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      -   uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+      - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       - uses: actions/cache@v3.3.1
       - uses: actions/setup-java@v3
       - uses: rharkor/caching-for-turbo@v1.6
       - uses: peaceiris/actions-gh-pages@v4.0.0
-      - 'uses': "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744" # v3.6.0
-      - "uses": 'actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744' # v3.6.0
+      - 'uses': "actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26" # v3.7.0
+      - "uses": 'actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26' # v3.7.0
       - uses: cardinalby/git-get-release-action@cf4593dd18e51a1ecfbfb1c68abac9910a8b1e0c # v1
   actionlint:
     uses: suzuki-shunsuke/actionlint-workflow/.github/workflows/actionlint.yaml@v0.5.0

--- a/testdata/separator/foo_after.yaml
+++ b/testdata/separator/foo_after.yaml
@@ -11,13 +11,13 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  #  v3.5.3
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  #  tag=v3.5.3
       - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247  # v3.5.1
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2.7.0
+      - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e  # v2.8.0
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8  # v3.3.1
       - uses: actions/setup-java@v3
       - uses: rharkor/caching-for-turbo@c3de885e542eec7eb01eb1a6a59e97c7a2448615  # v1.6
       - uses: peaceiris/actions-gh-pages@v4.0.0
-      - 'uses': "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744"  # v3.6.0
-      - "uses": 'actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744'  # v3.6.0
+      - 'uses': "actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26"  # v3.7.0
+      - "uses": 'actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26'  # v3.7.0
       - uses: cardinalby/git-get-release-action@cf4593dd18e51a1ecfbfb1c68abac9910a8b1e0c # v1
   actionlint:
     uses: suzuki-shunsuke/actionlint-workflow/.github/workflows/actionlint.yaml@b6a5f966d4504893b2aeb60cf2b0de8946e48504  # v0.5.0


### PR DESCRIPTION
## Why

The integration test resolves `actions/checkout@v2` and `actions/checkout@v3` against the real GitHub API, so the expected files break whenever the floating major tags move.

actions/checkout released v2.8.0 and v3.7.0, so the major tags now point to different commits:

| tag | before | after |
| --- | --- | --- |
| `v2` | `ee0669bd1cc54295c223e0bb666b733df41de1c5` (v2.7.0) | `0717577d45739eb3c851188b29f50ed6c0b2194e` (v2.8.0) |
| `v3` | `f43a0e5ff2bd294095638e18286ca9a3d1956744` (v3.6.0) | `a37ce9120846195fa4ece8f58b268e6043cb2f26` (v3.7.0) |

This made `diff testdata/foo.yaml testdata/foo_after.yaml` fail on unrelated PRs, e.g. https://github.com/suzuki-shunsuke/pinact/actions/runs/30055701464/job/89366764623?pr=1650

## What

Regenerated the affected expected files by running the integration test steps locally:

- `testdata/foo_after.yaml`
- `testdata/foo_include_after.yaml`
- `testdata/separator/foo_after.yaml`

`testdata/foo_exclude_after.yaml`, `testdata/actions.after`, `testdata/migrate`, and `testdata/diff-file` were verified locally and need no change. The v2.7.0 / v3.6.0 references in `testdata/bar.yaml`, `testdata/verify.yaml`, and `docs/codes/001.md` are intentional fixed commit hashes, so they are left as is.

`cmdx v` and `cmdx t` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)