### PR TITLE
feat: add update-repos command to pin actions across repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,22 @@ Update actions to latest versions:
 pinact run -update
 ```
 
+### Update Repositories: `update-repos`
+
+`update-repos` clones selected repositories, pins their GitHub Actions, and opens a pull request for each repository that changes. Use a GitHub App installation token with repository contents and pull-request write permission. GitHub signs the resulting commits as the App, which satisfies required signed-commit policies.
+
+```sh
+# Process every active, non-fork repository visible in the organization.
+pinact update-repos --org acme
+
+# Process one or more repositories.
+pinact update-repos --repo acme/api --repo acme/web
+```
+
+The command pins each repository's current action references by default. Use `--update` to upgrade actions, `--branch` to customize the pull-request branch, and `--base-branch` to override the repository default branch. `--include-forks` and `--include-archived` opt organization scans into those repositories. Branch references require an explicit `--branch-to-tag` match, for example `--branch-to-tag '^(main|master)$'`.
+
+Use `--dry-run` to clone and calculate changes without creating branches, commits, pushes, or pull requests. `--format json` emits the per-repository result summary for automation.
+
 ### Minimum Release Age (Cooldown): `-min-age`, `-verify-min-age`
 
 pinact supports two kinds of minimum release age checks:

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/suzuki-shunsuke/pinact/v4/pkg/cli/migrate"
 	"github.com/suzuki-shunsuke/pinact/v4/pkg/cli/run"
 	"github.com/suzuki-shunsuke/pinact/v4/pkg/cli/tokencmd"
+	"github.com/suzuki-shunsuke/pinact/v4/pkg/cli/updaterepos"
 	"github.com/suzuki-shunsuke/slog-util/slogutil"
 	"github.com/suzuki-shunsuke/urfave-cli-v3-util/urfave"
 	"github.com/urfave/cli/v3"
@@ -30,6 +31,7 @@ func Run(ctx context.Context, logger *slogutil.Logger, env *urfave.Env) error {
 		Commands: []*cli.Command{
 			initcmd.New(logger, globalFlags, env),
 			run.New(logger, globalFlags, env),
+			updaterepos.New(logger, globalFlags, env),
 			migrate.New(logger, globalFlags),
 			tokencmd.New(logger),
 		},

--- a/pkg/cli/updaterepos/command.go
+++ b/pkg/cli/updaterepos/command.go
@@ -1,0 +1,182 @@
+// Package updaterepos implements the update-repos command.
+package updaterepos
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/suzuki-shunsuke/pinact/v4/pkg/cli/gflag"
+	"github.com/suzuki-shunsuke/pinact/v4/pkg/controller/updaterepos"
+	"github.com/suzuki-shunsuke/pinact/v4/pkg/di"
+	"github.com/suzuki-shunsuke/pinact/v4/pkg/github"
+	"github.com/suzuki-shunsuke/slog-util/slogutil"
+	"github.com/suzuki-shunsuke/urfave-cli-v3-util/urfave"
+	"github.com/urfave/cli/v3"
+)
+
+func New(logger *slogutil.Logger, globalFlags *gflag.GlobalFlags, env *urfave.Env) *cli.Command {
+	r := &runner{}
+	return r.Command(logger, globalFlags, env)
+}
+
+type runner struct {
+	organizations, repositories, includeRepos, excludeRepos, includeActions, excludeActions, branchToTags []string
+	includeForks, includeArchived, dryRun, keepWorkdir, update, draft                                     bool
+	branch, baseBranch, prTitle, prBody, format                                                           string
+	concurrency, minAge                                                                                   int
+}
+
+func (r *runner) Command(logger *slogutil.Logger, globalFlags *gflag.GlobalFlags, env *urfave.Env) *cli.Command {
+	return &cli.Command{
+		Name:  "update-repos",
+		Usage: "Pin GitHub Actions across repositories and create pull requests",
+		Action: func(ctx context.Context, _ *cli.Command) error {
+			return r.action(ctx, logger, globalFlags, env)
+		},
+		Flags: r.flags(),
+	}
+}
+
+func (r *runner) flags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringSliceFlag{Name: "org", Destination: &r.organizations},
+		&cli.StringSliceFlag{Name: "repo", Destination: &r.repositories},
+		&cli.StringSliceFlag{Name: "include-repo", Destination: &r.includeRepos},
+		&cli.StringSliceFlag{Name: "exclude-repo", Destination: &r.excludeRepos},
+		&cli.BoolFlag{Name: "include-forks", Destination: &r.includeForks},
+		&cli.BoolFlag{Name: "include-archived", Destination: &r.includeArchived},
+		&cli.StringFlag{Name: "branch", Destination: &r.branch},
+		&cli.StringFlag{Name: "base-branch", Destination: &r.baseBranch},
+		&cli.StringFlag{Name: "pr-title", Destination: &r.prTitle},
+		&cli.StringFlag{Name: "pr-body", Destination: &r.prBody},
+		&cli.BoolFlag{Name: "draft", Destination: &r.draft},
+		&cli.BoolFlag{Name: "dry-run", Destination: &r.dryRun},
+		&cli.BoolFlag{Name: "keep-workdir", Destination: &r.keepWorkdir},
+		&cli.IntFlag{Name: "concurrency", Value: updaterepos.DefaultConcurrency, Destination: &r.concurrency},
+		&cli.BoolFlag{Name: "update", Destination: &r.update},
+		&cli.StringSliceFlag{Name: "include-action", Destination: &r.includeActions},
+		&cli.StringSliceFlag{Name: "exclude-action", Destination: &r.excludeActions},
+		&cli.StringSliceFlag{Name: "branch-to-tag", Destination: &r.branchToTags},
+		&cli.IntFlag{Name: "min-age", Destination: &r.minAge},
+		&cli.StringFlag{Name: "format", Destination: &r.format},
+	}
+}
+
+func (r *runner) action(ctx context.Context, logger *slogutil.Logger, globalFlags *gflag.GlobalFlags, env *urfave.Env) error {
+	param, err := r.param()
+	if err != nil {
+		return err
+	}
+	secrets := &di.Secrets{}
+	secrets.SetFromEnv(env.Getenv)
+	diFlags := &di.Flags{GlobalFlags: globalFlags}
+	di.SetEnv(diFlags, env.Getenv)
+	token, err := github.Token(ctx, logger.Logger, secrets.GitHubToken, diFlags.KeyringEnabled)
+	if err != nil {
+		return fmt.Errorf("get GitHub token: %w", err)
+	}
+	if token == "" {
+		return errors.New("a GitHub token is required to push branches and create pull requests")
+	}
+	client, err := newGitHubClient(ctx, logger, diFlags, token)
+	if err != nil {
+		return err
+	}
+	param.Token = token
+	param.GHESToken = secrets.GHESToken
+	param.Flags = diFlags
+	controller := updaterepos.New(client, param, os.Stdout, os.Stderr)
+	if _, err := controller.Run(ctx, logger.Logger); err != nil {
+		return fmt.Errorf("update repositories: %w", err)
+	}
+	return nil
+}
+
+func (r *runner) param() (updaterepos.Param, error) {
+	if len(r.organizations) == 0 && len(r.repositories) == 0 {
+		return updaterepos.Param{}, errors.New("at least one --org or --repo is required")
+	}
+	if r.concurrency < 1 {
+		return updaterepos.Param{}, errors.New("--concurrency must be at least 1")
+	}
+	if r.format != "" && r.format != "json" {
+		return updaterepos.Param{}, errors.New("--format must be 'json'")
+	}
+	filters, err := r.compileFilters()
+	if err != nil {
+		return updaterepos.Param{}, err
+	}
+	return updaterepos.Param{
+		Organizations:       r.organizations,
+		Repositories:        r.repositories,
+		IncludeRepositories: filters.includeRepos,
+		ExcludeRepositories: filters.excludeRepos,
+		IncludeForks:        r.includeForks,
+		IncludeArchived:     r.includeArchived,
+		Branch:              r.branch,
+		BaseBranch:          r.baseBranch,
+		PRTitle:             r.prTitle,
+		PRBody:              r.prBody,
+		Draft:               r.draft,
+		DryRun:              r.dryRun,
+		KeepWorkdir:         r.keepWorkdir,
+		Concurrency:         r.concurrency,
+		Update:              r.update,
+		IncludeActions:      filters.includeActions,
+		ExcludeActions:      filters.excludeActions,
+		BranchToTags:        filters.branchToTags,
+		MinAge:              r.minAge,
+		Format:              r.format,
+	}, nil
+}
+
+type filterRegexps struct {
+	includeRepos, excludeRepos, includeActions, excludeActions, branchToTags []*regexp.Regexp
+}
+
+func (r *runner) compileFilters() (filterRegexps, error) {
+	fields := [][]string{r.includeRepos, r.excludeRepos, r.includeActions, r.excludeActions, r.branchToTags}
+	compiled := make([][]*regexp.Regexp, len(fields))
+	for i, values := range fields {
+		re, err := compileRegexps(values)
+		if err != nil {
+			return filterRegexps{}, err
+		}
+		compiled[i] = re
+	}
+	return filterRegexps{
+		includeRepos: compiled[0], excludeRepos: compiled[1],
+		includeActions: compiled[2], excludeActions: compiled[3],
+		branchToTags: compiled[4],
+	}, nil
+}
+
+func newGitHubClient(ctx context.Context, logger *slogutil.Logger, flags *di.Flags, token string) (*github.Client, error) {
+	if apiURL := flags.GetAPIURL(); apiURL != "" {
+		client, err := github.NewWithBaseURL(ctx, apiURL, token)
+		if err != nil {
+			return nil, fmt.Errorf("create GitHub Enterprise client: %w", err)
+		}
+		return client, nil
+	}
+	client, err := github.New(ctx, logger.Logger, token, false)
+	if err != nil {
+		return nil, fmt.Errorf("create GitHub client: %w", err)
+	}
+	return client, nil
+}
+
+func compileRegexps(values []string) ([]*regexp.Regexp, error) {
+	out := make([]*regexp.Regexp, len(values))
+	for i, value := range values {
+		re, err := regexp.Compile(value)
+		if err != nil {
+			return nil, fmt.Errorf("compile regexp %q: %w", value, err)
+		}
+		out[i] = re
+	}
+	return out, nil
+}

--- a/pkg/cli/updaterepos/command.go
+++ b/pkg/cli/updaterepos/command.go
@@ -17,6 +17,8 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+const formatJSON = "json"
+
 func New(logger *slogutil.Logger, globalFlags *gflag.GlobalFlags, env *urfave.Env) *cli.Command {
 	r := &runner{}
 	return r.Command(logger, globalFlags, env)
@@ -102,7 +104,7 @@ func (r *runner) param() (updaterepos.Param, error) {
 	if r.concurrency < 1 {
 		return updaterepos.Param{}, errors.New("--concurrency must be at least 1")
 	}
-	if r.format != "" && r.format != "json" {
+	if r.format != "" && r.format != formatJSON {
 		return updaterepos.Param{}, errors.New("--format must be 'json'")
 	}
 	filters, err := r.compileFilters()

--- a/pkg/cli/updaterepos/command_test.go
+++ b/pkg/cli/updaterepos/command_test.go
@@ -1,0 +1,38 @@
+package updaterepos
+
+import "testing"
+
+func TestRunnerParam(t *testing.T) {
+	t.Parallel()
+	runner := &runner{
+		organizations: []string{"acme"},
+		repositories:  []string{"acme/service"},
+		includeRepos:  []string{"acme/.*"},
+		branchToTags:  []string{"^main$"},
+		concurrency:   2,
+		format:        "json",
+	}
+	param, err := runner.param()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(param.Organizations) != 1 || len(param.Repositories) != 1 || param.Concurrency != 2 || param.Format != "json" {
+		t.Fatalf("unexpected param: %#v", param)
+	}
+	if !param.IncludeRepositories[0].MatchString("acme/service") || !param.BranchToTags[0].MatchString("main") {
+		t.Fatalf("regular expressions were not compiled: %#v", param)
+	}
+}
+
+func TestRunnerParamRejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+	if _, err := (&runner{concurrency: 1}).param(); err == nil {
+		t.Fatal("param accepted no organization or repository")
+	}
+	if _, err := (&runner{organizations: []string{"acme"}, concurrency: 0}).param(); err == nil {
+		t.Fatal("param accepted invalid concurrency")
+	}
+	if _, err := (&runner{organizations: []string{"acme"}, concurrency: 1, includeRepos: []string{"["}}).param(); err == nil {
+		t.Fatal("param accepted invalid regular expression")
+	}
+}

--- a/pkg/cli/updaterepos/command_test.go
+++ b/pkg/cli/updaterepos/command_test.go
@@ -1,4 +1,4 @@
-package updaterepos
+package updaterepos //nolint:testpackage // tests unexported runner helpers
 
 import "testing"
 

--- a/pkg/controller/updaterepos/controller.go
+++ b/pkg/controller/updaterepos/controller.go
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	defaultBranch = "pinact/update-actions"
+	defaultBranch  = "pinact/update-actions"
+	defaultPRTitle = "chore: pin GitHub Actions"
 	// DefaultConcurrency is the default number of repositories processed in parallel.
 	DefaultConcurrency = 4
 	orgReposPerPage    = 100
@@ -86,7 +87,7 @@ func New(client *github.Client, param Param, stdout, stderr io.Writer) *Controll
 		param.Branch = defaultBranch
 	}
 	if param.PRTitle == "" {
-		param.PRTitle = "chore: pin GitHub Actions"
+		param.PRTitle = defaultPRTitle
 	}
 	if param.PRBody == "" {
 		param.PRBody = "Automated GitHub Actions pinning by pinact."
@@ -100,8 +101,8 @@ func New(client *github.Client, param Param, stdout, stderr io.Writer) *Controll
 	return controller
 }
 
-func newController(client *github.Client, service GitHubService, git GitRunner, pinner Pinner, param Param, stdout, stderr io.Writer) *Controller {
-	controller := New(client, param, stdout, stderr)
+func newController(service GitHubService, git GitRunner, pinner Pinner, param Param, stdout io.Writer) *Controller {
+	controller := New(nil, param, stdout, nil)
 	controller.service = service
 	if git != nil {
 		controller.git = git
@@ -331,14 +332,14 @@ func (c *Controller) syncRepository(ctx context.Context, logger *slog.Logger, re
 func (c *Controller) pinStatus(ctx context.Context, logger *slog.Logger, workdir string) (string, error) {
 	hasFiles, err := c.pinner.Pin(ctx, logger, workdir)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("pin repository: %w", err)
 	}
 	if !hasFiles {
 		return statusSkipped, nil
 	}
 	changed, err := c.git.Changed(ctx, workdir)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("check repository changes: %w", err)
 	}
 	if !changed {
 		return statusUnchanged, nil
@@ -428,7 +429,7 @@ func (c *Controller) parentCommit(ctx context.Context, owner, repo, base string,
 func (c *Controller) createChangedTree(ctx context.Context, owner, repo, workdir, parentTreeSHA string) (*ghapi.Tree, error) {
 	paths, err := c.git.ChangedFiles(ctx, workdir)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list changed files: %w", err)
 	}
 	entries := make([]*ghapi.TreeEntry, 0, len(paths))
 	for _, path := range paths {
@@ -646,7 +647,10 @@ func (c *Controller) pullRequest(ctx context.Context, repository *github.Reposit
 }
 
 func (c *Controller) runGit(ctx context.Context, dir string, args ...string) error {
-	return c.git.Run(ctx, dir, c.stdout, c.stderr, args...)
+	if err := c.git.Run(ctx, dir, c.stdout, c.stderr, args...); err != nil {
+		return fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
+	}
+	return nil
 }
 
 func (c *Controller) executeGit(ctx context.Context, dir string, stdout, stderr io.Writer, args ...string) error {

--- a/pkg/controller/updaterepos/controller.go
+++ b/pkg/controller/updaterepos/controller.go
@@ -1,0 +1,716 @@
+// Package updaterepos updates GitHub Actions pins across GitHub repositories.
+package updaterepos
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	ghapi "github.com/google/go-github/v90/github"
+	"github.com/spf13/afero"
+	"github.com/suzuki-shunsuke/pinact/v4/pkg/config"
+	"github.com/suzuki-shunsuke/pinact/v4/pkg/controller/run"
+	"github.com/suzuki-shunsuke/pinact/v4/pkg/di"
+	"github.com/suzuki-shunsuke/pinact/v4/pkg/github"
+)
+
+const (
+	defaultBranch = "pinact/update-actions"
+	// DefaultConcurrency is the default number of repositories processed in parallel.
+	DefaultConcurrency = 4
+	orgReposPerPage    = 100
+	gitAskpassPerm     = 0o700
+	statusChanged      = "changed"
+	statusSkipped      = "skipped"
+	statusUnchanged    = "unchanged"
+	statusFailed       = "failed"
+)
+
+type Param struct {
+	Organizations       []string
+	Repositories        []string
+	IncludeRepositories []*regexp.Regexp
+	ExcludeRepositories []*regexp.Regexp
+	IncludeForks        bool
+	IncludeArchived     bool
+	Branch              string
+	BaseBranch          string
+	PRTitle             string
+	PRBody              string
+	Draft               bool
+	DryRun              bool
+	KeepWorkdir         bool
+	Concurrency         int
+	Update              bool
+	IncludeActions      []*regexp.Regexp
+	ExcludeActions      []*regexp.Regexp
+	BranchToTags        []*regexp.Regexp
+	MinAge              int
+	Format              string
+	Token               string
+	GHESToken           string
+	Flags               *di.Flags
+}
+
+type Result struct {
+	Repository string `json:"repository"`
+	Status     string `json:"status"`
+	PRURL      string `json:"pr_url,omitempty"`
+	Workdir    string `json:"workdir,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+type Controller struct {
+	client  *github.Client
+	service GitHubService
+	git     GitRunner
+	pinner  Pinner
+	param   Param
+	stdout  io.Writer
+	stderr  io.Writer
+}
+
+func New(client *github.Client, param Param, stdout, stderr io.Writer) *Controller {
+	if param.Branch == "" {
+		param.Branch = defaultBranch
+	}
+	if param.PRTitle == "" {
+		param.PRTitle = "chore: pin GitHub Actions"
+	}
+	if param.PRBody == "" {
+		param.PRBody = "Automated GitHub Actions pinning by pinact."
+	}
+	if param.Concurrency == 0 {
+		param.Concurrency = DefaultConcurrency
+	}
+	controller := &Controller{client: client, service: newGitHubService(client), param: param, stdout: stdout, stderr: stderr}
+	controller.git = localGitRunner{controller: controller}
+	controller.pinner = controllerPinner{controller: controller}
+	return controller
+}
+
+func newController(client *github.Client, service GitHubService, git GitRunner, pinner Pinner, param Param, stdout, stderr io.Writer) *Controller {
+	controller := New(client, param, stdout, stderr)
+	controller.service = service
+	if git != nil {
+		controller.git = git
+	}
+	if pinner != nil {
+		controller.pinner = pinner
+	}
+	return controller
+}
+
+func (c *Controller) Run(ctx context.Context, logger *slog.Logger) ([]Result, error) {
+	repositories, err := c.repositories(ctx)
+	if err != nil {
+		return nil, err
+	}
+	jobs := make(chan *github.Repository)
+	results := make(chan Result, len(repositories))
+	var wg sync.WaitGroup
+	for range c.param.Concurrency {
+		wg.Go(func() {
+			for repository := range jobs {
+				results <- c.process(ctx, logger, repository)
+			}
+		})
+	}
+	go func() {
+		for _, repository := range repositories {
+			jobs <- repository
+		}
+		close(jobs)
+		wg.Wait()
+		close(results)
+	}()
+	all := make([]Result, 0, len(repositories))
+	failed := false
+	for result := range results {
+		all = append(all, result)
+		if result.Status == statusFailed {
+			failed = true
+		}
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].Repository < all[j].Repository })
+	c.output(all)
+	if failed {
+		return all, errors.New("one or more repositories failed")
+	}
+	return all, nil
+}
+
+func (c *Controller) repositories(ctx context.Context) ([]*github.Repository, error) {
+	seen := map[string]*github.Repository{}
+	explicit := map[string]bool{}
+	if err := c.addExplicitRepositories(ctx, seen, explicit); err != nil {
+		return nil, err
+	}
+	if err := c.addOrganizationRepositories(ctx, seen); err != nil {
+		return nil, err
+	}
+	return c.filterRepositories(seen, explicit), nil
+}
+
+func (c *Controller) addExplicitRepositories(ctx context.Context, seen map[string]*github.Repository, explicit map[string]bool) error {
+	for _, fullName := range c.param.Repositories {
+		owner, name, err := parseRepoFullName(fullName)
+		if err != nil {
+			return err
+		}
+		repository, err := c.service.GetRepository(ctx, owner, name)
+		if err != nil {
+			return fmt.Errorf("get repository %s: %w", fullName, err)
+		}
+		seen[repository.GetFullName()] = repository
+		explicit[repository.GetFullName()] = true
+	}
+	return nil
+}
+
+func parseRepoFullName(fullName string) (string, string, error) {
+	owner, name, ok := strings.Cut(fullName, "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		return "", "", fmt.Errorf("repository must be in owner/name form: %s", fullName)
+	}
+	return owner, name, nil
+}
+
+func (c *Controller) addOrganizationRepositories(ctx context.Context, seen map[string]*github.Repository) error {
+	for _, org := range c.param.Organizations {
+		if err := c.listOrganizationRepositories(ctx, org, seen); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Controller) listOrganizationRepositories(ctx context.Context, org string, seen map[string]*github.Repository) error {
+	page := 0
+	for {
+		repositories, nextPage, err := c.service.ListOrganizationRepositories(ctx, org, page)
+		if err != nil {
+			return fmt.Errorf("list repositories for organization %s: %w", org, err)
+		}
+		for _, repository := range repositories {
+			seen[repository.GetFullName()] = repository
+		}
+		if nextPage == 0 {
+			return nil
+		}
+		page = nextPage
+	}
+}
+
+func (c *Controller) filterRepositories(seen map[string]*github.Repository, explicit map[string]bool) []*github.Repository {
+	result := make([]*github.Repository, 0, len(seen))
+	for _, repository := range seen {
+		name := repository.GetFullName()
+		if c.excluded(name) {
+			continue
+		}
+		if !explicit[name] && !c.selected(repository) {
+			continue
+		}
+		result = append(result, repository)
+	}
+	return result
+}
+
+func (c *Controller) selected(repository *github.Repository) bool {
+	if repository.GetArchived() && !c.param.IncludeArchived {
+		return false
+	}
+	if repository.GetFork() && !c.param.IncludeForks {
+		return false
+	}
+	name := repository.GetFullName()
+	if c.excluded(name) {
+		return false
+	}
+	if len(c.param.IncludeRepositories) == 0 {
+		return true
+	}
+	for _, pattern := range c.param.IncludeRepositories {
+		if pattern.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Controller) excluded(name string) bool {
+	for _, pattern := range c.param.ExcludeRepositories {
+		if pattern.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Controller) process(ctx context.Context, logger *slog.Logger, repository *github.Repository) Result {
+	result := Result{Repository: repository.GetFullName()}
+	workdir, cleanup, err := c.makeWorkdir()
+	if err != nil {
+		return c.fail(result, err)
+	}
+	defer cleanup()
+	if c.param.KeepWorkdir {
+		result.Workdir = workdir
+	}
+	base, err := c.cloneAndCheckoutBase(ctx, repository, workdir)
+	if err != nil {
+		return c.fail(result, err)
+	}
+	return c.syncRepository(ctx, logger, repository, workdir, base, result)
+}
+
+func (c *Controller) makeWorkdir() (string, func(), error) {
+	workdir, err := os.MkdirTemp("", "pinact-update-repos-")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temporary directory: %w", err)
+	}
+	cleanup := func() {}
+	if !c.param.KeepWorkdir {
+		cleanup = func() { os.RemoveAll(workdir) }
+	}
+	return workdir, cleanup, nil
+}
+
+func (c *Controller) cloneAndCheckoutBase(ctx context.Context, repository *github.Repository, workdir string) (string, error) {
+	if err := c.runGit(ctx, workdir, "clone", "--quiet", repository.GetCloneURL(), "."); err != nil {
+		return "", err
+	}
+	base := repository.GetDefaultBranch()
+	if c.param.BaseBranch != "" {
+		base = c.param.BaseBranch
+	}
+	if err := c.runGit(ctx, workdir, "checkout", "--quiet", base); err != nil {
+		return "", fmt.Errorf("checkout base branch %s: %w", base, err)
+	}
+	return base, nil
+}
+
+func (c *Controller) syncRepository(ctx context.Context, logger *slog.Logger, repository *github.Repository, workdir, base string, result Result) Result {
+	branchExists, err := c.branchExists(ctx, workdir)
+	if err != nil {
+		return c.fail(result, err)
+	}
+	status, err := c.pinStatus(ctx, logger, workdir)
+	if err != nil {
+		return c.fail(result, err)
+	}
+	if status != statusChanged {
+		result.Status = status
+		return result
+	}
+	if c.param.DryRun {
+		result.Status = statusChanged
+		return result
+	}
+	prURL, status, err := c.commitAndOpenPR(ctx, logger, repository, workdir, base, branchExists)
+	if err != nil {
+		return c.fail(result, err)
+	}
+	result.Status = status
+	result.PRURL = prURL
+	return result
+}
+
+func (c *Controller) pinStatus(ctx context.Context, logger *slog.Logger, workdir string) (string, error) {
+	hasFiles, err := c.pinner.Pin(ctx, logger, workdir)
+	if err != nil {
+		return "", err
+	}
+	if !hasFiles {
+		return statusSkipped, nil
+	}
+	changed, err := c.git.Changed(ctx, workdir)
+	if err != nil {
+		return "", err
+	}
+	if !changed {
+		return statusUnchanged, nil
+	}
+	return statusChanged, nil
+}
+
+func (c *Controller) commitAndOpenPR(ctx context.Context, logger *slog.Logger, repository *github.Repository, workdir, base string, branchExists bool) (string, string, error) {
+	if err := c.runGit(ctx, workdir, "reset", "--hard"); err != nil {
+		return "", "", err
+	}
+	existingPR, err := c.existingPullRequest(ctx, repository, base)
+	if err != nil {
+		return "", "", err
+	}
+	if err := c.checkoutBranch(ctx, workdir, base, branchExists); err != nil {
+		return "", "", err
+	}
+	status, err := c.pinStatus(ctx, logger, workdir)
+	if err != nil {
+		return "", "", err
+	}
+	if status != statusChanged {
+		return existingPRURL(existingPR), status, nil
+	}
+	if err := c.commitChanges(ctx, repository, workdir, base, branchExists); err != nil {
+		return "", "", err
+	}
+	pr, err := c.pullRequest(ctx, repository, base, existingPR)
+	if err != nil {
+		return "", "", err
+	}
+	return pr.GetHTMLURL(), statusChanged, nil
+}
+
+func existingPRURL(pr *ghapi.PullRequest) string {
+	if pr == nil {
+		return ""
+	}
+	return pr.GetHTMLURL()
+}
+
+// commitChanges creates the commit through GitHub's Git Data API. When the
+// token is an installation token, GitHub signs the commit as the App as long
+// as author and committer are omitted.
+func (c *Controller) commitChanges(ctx context.Context, repository *github.Repository, workdir, base string, branchExists bool) error {
+	owner, repo := repository.GetOwner().GetLogin(), repository.GetName()
+	parentSHA, parentTreeSHA, err := c.parentCommit(ctx, owner, repo, base, branchExists)
+	if err != nil {
+		return err
+	}
+	tree, err := c.createChangedTree(ctx, owner, repo, workdir, parentTreeSHA)
+	if err != nil {
+		return err
+	}
+	commit, err := c.service.CreateCommit(ctx, owner, repo, ghapi.Commit{
+		Message: github.Ptr(c.param.PRTitle),
+		Tree:    tree,
+		Parents: []*ghapi.Commit{{SHA: github.Ptr(parentSHA)}},
+	})
+	if err != nil {
+		return fmt.Errorf("create commit: %w", err)
+	}
+	if !commit.GetVerification().GetVerified() {
+		return fmt.Errorf("GitHub did not verify the App commit: %s", commit.GetVerification().GetReason())
+	}
+	return c.publishBranch(ctx, owner, repo, commit.GetSHA(), branchExists)
+}
+
+func (c *Controller) parentCommit(ctx context.Context, owner, repo, base string, branchExists bool) (string, string, error) {
+	parentBranch := base
+	if branchExists {
+		parentBranch = c.param.Branch
+	}
+	ref, err := c.service.GetRef(ctx, owner, repo, "heads/"+parentBranch)
+	if err != nil {
+		return "", "", fmt.Errorf("get branch %s: %w", parentBranch, err)
+	}
+	parentSHA := ref.GetObject().GetSHA()
+	parent, err := c.service.GetCommit(ctx, owner, repo, parentSHA)
+	if err != nil {
+		return "", "", fmt.Errorf("get parent commit: %w", err)
+	}
+	return parentSHA, parent.GetTree().GetSHA(), nil
+}
+
+func (c *Controller) createChangedTree(ctx context.Context, owner, repo, workdir, parentTreeSHA string) (*ghapi.Tree, error) {
+	paths, err := c.git.ChangedFiles(ctx, workdir)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]*ghapi.TreeEntry, 0, len(paths))
+	for _, path := range paths {
+		entry, err := c.blobEntry(ctx, owner, repo, workdir, path)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
+	}
+	tree, err := c.service.CreateTree(ctx, owner, repo, parentTreeSHA, entries)
+	if err != nil {
+		return nil, fmt.Errorf("create tree: %w", err)
+	}
+	return tree, nil
+}
+
+func (c *Controller) blobEntry(ctx context.Context, owner, repo, workdir, path string) (*ghapi.TreeEntry, error) {
+	content, err := os.ReadFile(filepath.Join(workdir, path))
+	if err != nil {
+		return nil, fmt.Errorf("read changed file %s: %w", path, err)
+	}
+	blob, err := c.service.CreateBlob(ctx, owner, repo, ghapi.Blob{
+		Content:  github.Ptr(string(content)),
+		Encoding: github.Ptr("utf-8"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create blob for %s: %w", path, err)
+	}
+	return &ghapi.TreeEntry{
+		Path: github.Ptr(path),
+		Mode: github.Ptr("100644"),
+		Type: github.Ptr("blob"),
+		SHA:  github.Ptr(blob.GetSHA()),
+	}, nil
+}
+
+func (c *Controller) publishBranch(ctx context.Context, owner, repo, sha string, branchExists bool) error {
+	var err error
+	if branchExists {
+		err = c.service.UpdateRef(ctx, owner, repo, "heads/"+c.param.Branch, ghapi.UpdateRef{
+			SHA:   sha,
+			Force: github.Ptr(false),
+		})
+	} else {
+		err = c.service.CreateRef(ctx, owner, repo, ghapi.CreateRef{
+			Ref: "refs/heads/" + c.param.Branch,
+			SHA: sha,
+		})
+	}
+	if err != nil {
+		return fmt.Errorf("update branch %s: %w", c.param.Branch, err)
+	}
+	return nil
+}
+
+func (c *Controller) pin(ctx context.Context, logger *slog.Logger, workdir string) (bool, error) {
+	cfg, configPath, err := readConfig(workdir)
+	if err != nil {
+		return false, err
+	}
+	services, err := di.SetupGHESServices(ctx, c.client, cfg, c.param.Flags, c.param.GHESToken)
+	if err != nil {
+		return false, fmt.Errorf("set up GitHub services: %w", err)
+	}
+	files, err := workflowFiles(workdir, cfg, configPath)
+	if err != nil {
+		return false, err
+	}
+	if len(files) == 0 {
+		return false, nil
+	}
+	ctrl := run.New(services.RepoService, services.GitService, afero.NewOsFs(), cfg, &run.ParamRun{
+		WorkflowFilePaths: files, ConfigFilePath: configPath, CWD: workdir, Fix: true, Update: c.param.Update,
+		Stderr: c.stderr, Stdout: c.stdout, Includes: c.param.IncludeActions, Excludes: c.param.ExcludeActions,
+		BranchToTags: c.param.BranchToTags, MinAge: c.param.MinAge,
+		Now: time.Now(),
+	})
+	if err := ctrl.Run(ctx, logger); err != nil {
+		return true, fmt.Errorf("pin actions: %w", err)
+	}
+	return true, nil
+}
+
+func readConfig(workdir string) (*config.Config, string, error) {
+	fs := afero.NewOsFs()
+	configPath, err := findConfigPath(workdir)
+	if err != nil {
+		return nil, "", err
+	}
+	globalPath, err := config.NewFinder(fs).FindGlobal()
+	if err != nil {
+		return nil, "", fmt.Errorf("find global configuration: %w", err)
+	}
+	cfg := &config.Config{Separator: " # "}
+	if configPath == "" && globalPath == "" {
+		return cfg, configPath, nil
+	}
+	if err := config.NewReader(fs).ReadAndMerge(cfg, configPath, globalPath); err != nil {
+		return nil, "", fmt.Errorf("read configuration: %w", err)
+	}
+	if cfg.Separator == "" {
+		cfg.Separator = " # "
+	}
+	return cfg, configPath, nil
+}
+
+func findConfigPath(workdir string) (string, error) {
+	paths := []string{".pinact.yaml", ".github/pinact.yaml", ".pinact.yml", ".github/pinact.yml"}
+	for _, path := range paths {
+		candidate := filepath.Join(workdir, path)
+		_, err := os.Stat(candidate)
+		if err == nil {
+			return candidate, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("stat config file %s: %w", path, err)
+		}
+	}
+	return "", nil
+}
+
+func workflowFiles(workdir string, cfg *config.Config, configPath string) ([]string, error) {
+	if len(cfg.Files) > 0 {
+		return globConfigFiles(workdir, cfg, configPath)
+	}
+	patterns := []string{
+		".github/workflows/*.yml", ".github/workflows/*.yaml",
+		"action.yml", "action.yaml",
+		"*/action.yml", "*/action.yaml",
+		"*/*/action.yml", "*/*/action.yaml",
+		"*/*/*/action.yml", "*/*/*/action.yaml",
+	}
+	return globPatterns(workdir, patterns)
+}
+
+func globConfigFiles(workdir string, cfg *config.Config, configPath string) ([]string, error) {
+	files := make([]string, 0, len(cfg.Files))
+	for _, file := range cfg.Files {
+		base := workdir
+		if configPath != "" {
+			base = filepath.Dir(configPath)
+		}
+		matches, err := filepath.Glob(filepath.Join(base, file.Pattern))
+		if err != nil {
+			return nil, fmt.Errorf("glob %s: %w", file.Pattern, err)
+		}
+		files = append(files, matches...)
+	}
+	return files, nil
+}
+
+func globPatterns(workdir string, patterns []string) ([]string, error) {
+	var files []string
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(filepath.Join(workdir, pattern))
+		if err != nil {
+			return nil, fmt.Errorf("glob %s: %w", pattern, err)
+		}
+		files = append(files, matches...)
+	}
+	return files, nil
+}
+
+func (c *Controller) branchExists(ctx context.Context, workdir string) (bool, error) {
+	err := c.git.Run(ctx, workdir, io.Discard, io.Discard, "ls-remote", "--exit-code", "--heads", "origin", c.param.Branch)
+	if err == nil {
+		return true, nil
+	}
+	var exit *exec.ExitError
+	if errors.As(err, &exit) && exit.ExitCode() == 2 {
+		return false, nil
+	}
+	return false, fmt.Errorf("check branch %s: %w", c.param.Branch, err)
+}
+
+func (c *Controller) checkoutBranch(ctx context.Context, workdir, base string, branchExists bool) error {
+	if branchExists {
+		if err := c.runGit(ctx, workdir, "fetch", "--quiet", "origin", c.param.Branch); err != nil {
+			return fmt.Errorf("fetch branch %s: %w", c.param.Branch, err)
+		}
+		return c.runGit(ctx, workdir, "checkout", "--quiet", "-B", c.param.Branch, "origin/"+c.param.Branch)
+	}
+	return c.runGit(ctx, workdir, "checkout", "--quiet", "-b", c.param.Branch, base)
+}
+
+func (c *Controller) existingPullRequest(ctx context.Context, repository *github.Repository, base string) (*ghapi.PullRequest, error) {
+	prs, err := c.service.ListOpenPullRequests(ctx, repository.GetOwner().GetLogin(), repository.GetName(), repository.GetOwner().GetLogin()+":"+c.param.Branch)
+	if err != nil {
+		return nil, fmt.Errorf("find existing pull request: %w", err)
+	}
+	if len(prs) == 0 {
+		return nil, nil //nolint:nilnil // no open pull request is a valid result
+	}
+	if prs[0].GetBase().GetRef() != base {
+		return nil, fmt.Errorf("existing pull request targets %s instead of %s", prs[0].GetBase().GetRef(), base)
+	}
+	return prs[0], nil
+}
+
+func (c *Controller) pullRequest(ctx context.Context, repository *github.Repository, base string, existing *ghapi.PullRequest) (*ghapi.PullRequest, error) {
+	if existing != nil {
+		return existing, nil
+	}
+	pr, err := c.service.CreatePullRequest(ctx, repository.GetOwner().GetLogin(), repository.GetName(), ghapi.CreatePullRequest{
+		Title: github.Ptr(c.param.PRTitle),
+		Head:  c.param.Branch,
+		Base:  base,
+		Body:  github.Ptr(c.param.PRBody),
+		Draft: github.Ptr(c.param.Draft),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create pull request: %w", err)
+	}
+	return pr, nil
+}
+
+func (c *Controller) runGit(ctx context.Context, dir string, args ...string) error {
+	return c.git.Run(ctx, dir, c.stdout, c.stderr, args...)
+}
+
+func (c *Controller) executeGit(ctx context.Context, dir string, stdout, stderr io.Writer, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	cmd.Stderr = stderr
+	cmd.Stdout = stdout
+	if c.param.Token != "" {
+		path, err := c.writeGitAskpass()
+		if err != nil {
+			return err
+		}
+		defer os.Remove(path)
+		cmd.Env = append(os.Environ(), "GIT_ASKPASS="+path, "GIT_TERMINAL_PROMPT=0", "PINACT_GIT_TOKEN="+c.param.Token)
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+func (c *Controller) writeGitAskpass() (string, error) {
+	askpass, err := os.CreateTemp("", "pinact-git-askpass-")
+	if err != nil {
+		return "", fmt.Errorf("create Git credential helper: %w", err)
+	}
+	path := askpass.Name()
+	if _, err := askpass.WriteString("#!/bin/sh\ncase \"$1\" in *Username*) printf '%s\\n' x-access-token ;; *) printf '%s\\n' \"$PINACT_GIT_TOKEN\" ;; esac\n"); err != nil {
+		askpass.Close()
+		os.Remove(path)
+		return "", fmt.Errorf("write Git credential helper: %w", err)
+	}
+	if err := askpass.Close(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("close Git credential helper: %w", err)
+	}
+	if err := os.Chmod(path, gitAskpassPerm); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("make Git credential helper executable: %w", err)
+	}
+	return path, nil
+}
+
+func (c *Controller) fail(result Result, err error) Result {
+	result.Status = statusFailed
+	result.Error = err.Error()
+	return result
+}
+
+func (c *Controller) output(results []Result) {
+	if c.param.Format == "json" {
+		if err := json.NewEncoder(c.stdout).Encode(results); err != nil {
+			fmt.Fprintf(c.stderr, "encode JSON results: %v\n", err)
+		}
+		return
+	}
+	for _, result := range results {
+		switch {
+		case result.Error != "":
+			fmt.Fprintf(c.stdout, "%s: %s: %s\n", result.Repository, result.Status, result.Error)
+		case result.PRURL != "":
+			fmt.Fprintf(c.stdout, "%s: %s: %s\n", result.Repository, result.Status, result.PRURL)
+		default:
+			fmt.Fprintf(c.stdout, "%s: %s\n", result.Repository, result.Status)
+		}
+	}
+}

--- a/pkg/controller/updaterepos/controller_test.go
+++ b/pkg/controller/updaterepos/controller_test.go
@@ -1,0 +1,132 @@
+package updaterepos //nolint:testpackage // tests unexported helpers
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/suzuki-shunsuke/pinact/v4/pkg/config"
+	"github.com/suzuki-shunsuke/pinact/v4/pkg/github"
+)
+
+func TestControllerSelected(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		param Param
+		repo  *github.Repository
+		want  bool
+	}{
+		"active repository": {
+			repo: &github.Repository{FullName: github.Ptr("acme/service")},
+			want: true,
+		},
+		"archived repository": {
+			repo: &github.Repository{FullName: github.Ptr("acme/service"), Archived: github.Ptr(true)},
+		},
+		"included archived repository": {
+			param: Param{IncludeArchived: true},
+			repo:  &github.Repository{FullName: github.Ptr("acme/service"), Archived: github.Ptr(true)},
+			want:  true,
+		},
+		"fork repository": {
+			repo: &github.Repository{FullName: github.Ptr("acme/service"), Fork: github.Ptr(true)},
+		},
+		"excluded repository wins": {
+			param: Param{IncludeRepositories: []*regexp.Regexp{regexp.MustCompile("acme/.*")}, ExcludeRepositories: []*regexp.Regexp{regexp.MustCompile("service")}},
+			repo:  &github.Repository{FullName: github.Ptr("acme/service")},
+		},
+		"included repository": {
+			param: Param{IncludeRepositories: []*regexp.Regexp{regexp.MustCompile("acme/service")}},
+			repo:  &github.Repository{FullName: github.Ptr("acme/service")},
+			want:  true,
+		},
+	}
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			controller := New(nil, test.param, nil, nil)
+			if got := controller.selected(test.repo); got != test.want {
+				t.Errorf("selected() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNewDefaults(t *testing.T) {
+	t.Parallel()
+	controller := New(nil, Param{}, nil, nil)
+	if diff := cmp.Diff(defaultBranch, controller.param.Branch); diff != "" {
+		t.Errorf("branch (-want +got):\n%s", diff)
+	}
+	if controller.param.Concurrency != DefaultConcurrency {
+		t.Errorf("concurrency = %d, want %d", controller.param.Concurrency, DefaultConcurrency)
+	}
+}
+
+func TestWorkflowFilesUsesConfiguration(t *testing.T) {
+	t.Parallel()
+	workdir := t.TempDir()
+	configPath := filepath.Join(workdir, ".pinact.yaml")
+	if err := os.WriteFile(filepath.Join(workdir, "README.md"), []byte("uses: actions/checkout@v4\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	files, err := workflowFiles(workdir, &config.Config{Files: []*config.File{{Pattern: "README.md"}}}, configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{filepath.Join(workdir, "README.md")}
+	if diff := cmp.Diff(want, files); diff != "" {
+		t.Errorf("workflowFiles() (-want +got):\n%s", diff)
+	}
+}
+
+func TestReadConfigMergesGlobalConfig(t *testing.T) {
+	workdir := t.TempDir()
+	globalPath := filepath.Join(t.TempDir(), "pinact.yaml")
+	if err := os.WriteFile(globalPath, []byte("version: 3\nghes:\n  api_url: https://ghes.example.com/api/v3\n  fallback: true\nignore_actions:\n  - name: actions/checkout\n    ref: .*\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, ".pinact.yaml"), []byte("version: 3\nignore_actions:\n  - name: actions/setup-go\n    ref: .*\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PINACT_GLOBAL_CONFIG", globalPath)
+	cfg, configPath, err := readConfig(workdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPath := filepath.Join(workdir, ".pinact.yaml")
+	ghesURL := ""
+	ghesFallback := false
+	if cfg.GHES != nil {
+		ghesURL = cfg.GHES.APIURL
+		ghesFallback = cfg.GHES.Fallback
+	}
+	names := make([]string, 0, len(cfg.IgnoreActions))
+	for _, action := range cfg.IgnoreActions {
+		names = append(names, action.Name)
+	}
+	if configPath != wantPath || ghesURL != "https://ghes.example.com/api/v3" || !ghesFallback {
+		t.Errorf("configPath=%s GHES=%+v, want path %s with global GHES fallback", configPath, cfg.GHES, wantPath)
+	}
+	if diff := cmp.Diff([]string{"actions/checkout", "actions/setup-go"}, names); diff != "" {
+		t.Errorf("IgnoreActions (-want +got):\n%s", diff)
+	}
+}
+
+func TestWorkflowFilesUsesWorkdirWhenConfigPathEmpty(t *testing.T) {
+	t.Parallel()
+	workdir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workdir, "README.md"), []byte("uses: actions/checkout@v4\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	files, err := workflowFiles(workdir, &config.Config{Files: []*config.File{{Pattern: "README.md"}}}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{filepath.Join(workdir, "README.md")}
+	if diff := cmp.Diff(want, files); diff != "" {
+		t.Errorf("workflowFiles() (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/controller/updaterepos/github_service.go
+++ b/pkg/controller/updaterepos/github_service.go
@@ -1,0 +1,86 @@
+package updaterepos
+
+import (
+	"context"
+
+	ghapi "github.com/google/go-github/v90/github"
+	"github.com/suzuki-shunsuke/pinact/v4/pkg/github"
+)
+
+// GitHubService contains only the GitHub operations update-repos orchestrates.
+// Keeping this surface narrow makes the controller independently testable.
+type GitHubService interface {
+	GetRepository(ctx context.Context, owner, repo string) (*github.Repository, error)
+	ListOrganizationRepositories(ctx context.Context, org string, page int) ([]*github.Repository, int, error)
+	GetRef(ctx context.Context, owner, repo, branch string) (*ghapi.Reference, error)
+	GetCommit(ctx context.Context, owner, repo, sha string) (*ghapi.Commit, error)
+	CreateBlob(ctx context.Context, owner, repo string, blob ghapi.Blob) (*ghapi.Blob, error)
+	CreateTree(ctx context.Context, owner, repo, baseTree string, entries []*ghapi.TreeEntry) (*ghapi.Tree, error)
+	CreateCommit(ctx context.Context, owner, repo string, commit ghapi.Commit) (*ghapi.Commit, error)
+	CreateRef(ctx context.Context, owner, repo string, ref ghapi.CreateRef) error
+	UpdateRef(ctx context.Context, owner, repo, branch string, ref ghapi.UpdateRef) error
+	ListOpenPullRequests(ctx context.Context, owner, repo, head string) ([]*ghapi.PullRequest, error)
+	CreatePullRequest(ctx context.Context, owner, repo string, pr ghapi.CreatePullRequest) (*ghapi.PullRequest, error)
+}
+
+type githubService struct{ client *github.Client }
+
+func newGitHubService(client *github.Client) GitHubService { return &githubService{client: client} }
+
+func (s *githubService) GetRepository(ctx context.Context, owner, repo string) (*github.Repository, error) {
+	repository, _, err := s.client.Repositories.Get(ctx, owner, repo)
+	return repository, err
+}
+
+func (s *githubService) ListOrganizationRepositories(ctx context.Context, org string, page int) ([]*github.Repository, int, error) {
+	repositories, response, err := s.client.Repositories.ListByOrg(ctx, org, &ghapi.RepositoryListByOrgOptions{ListOptions: ghapi.ListOptions{Page: page, PerPage: orgReposPerPage}, Type: "all"})
+	if err != nil {
+		return nil, 0, err
+	}
+	return repositories, response.NextPage, nil
+}
+
+func (s *githubService) GetRef(ctx context.Context, owner, repo, branch string) (*ghapi.Reference, error) {
+	ref, _, err := s.client.Git.GetRef(ctx, owner, repo, branch)
+	return ref, err
+}
+
+func (s *githubService) GetCommit(ctx context.Context, owner, repo, sha string) (*ghapi.Commit, error) {
+	commit, _, err := s.client.Git.GetCommit(ctx, owner, repo, sha)
+	return commit, err
+}
+
+func (s *githubService) CreateBlob(ctx context.Context, owner, repo string, blob ghapi.Blob) (*ghapi.Blob, error) {
+	created, _, err := s.client.Git.CreateBlob(ctx, owner, repo, blob)
+	return created, err
+}
+
+func (s *githubService) CreateTree(ctx context.Context, owner, repo, baseTree string, entries []*ghapi.TreeEntry) (*ghapi.Tree, error) {
+	tree, _, err := s.client.Git.CreateTree(ctx, owner, repo, baseTree, entries)
+	return tree, err
+}
+
+func (s *githubService) CreateCommit(ctx context.Context, owner, repo string, commit ghapi.Commit) (*ghapi.Commit, error) {
+	created, _, err := s.client.Git.CreateCommit(ctx, owner, repo, commit, nil)
+	return created, err
+}
+
+func (s *githubService) CreateRef(ctx context.Context, owner, repo string, ref ghapi.CreateRef) error {
+	_, _, err := s.client.Git.CreateRef(ctx, owner, repo, ref)
+	return err
+}
+
+func (s *githubService) UpdateRef(ctx context.Context, owner, repo, branch string, ref ghapi.UpdateRef) error {
+	_, _, err := s.client.Git.UpdateRef(ctx, owner, repo, branch, ref)
+	return err
+}
+
+func (s *githubService) ListOpenPullRequests(ctx context.Context, owner, repo, head string) ([]*ghapi.PullRequest, error) {
+	prs, _, err := s.client.PullRequests.List(ctx, owner, repo, &ghapi.PullRequestListOptions{Head: head, State: "open"})
+	return prs, err
+}
+
+func (s *githubService) CreatePullRequest(ctx context.Context, owner, repo string, pr ghapi.CreatePullRequest) (*ghapi.PullRequest, error) {
+	created, _, err := s.client.PullRequests.Create(ctx, owner, repo, pr)
+	return created, err
+}

--- a/pkg/controller/updaterepos/github_service.go
+++ b/pkg/controller/updaterepos/github_service.go
@@ -2,6 +2,7 @@ package updaterepos
 
 import (
 	"context"
+	"fmt"
 
 	ghapi "github.com/google/go-github/v90/github"
 	"github.com/suzuki-shunsuke/pinact/v4/pkg/github"
@@ -9,6 +10,8 @@ import (
 
 // GitHubService contains only the GitHub operations update-repos orchestrates.
 // Keeping this surface narrow makes the controller independently testable.
+//
+//nolint:interfacebloat // GitHub's Git Data workflow requires all of these operations.
 type GitHubService interface {
 	GetRepository(ctx context.Context, owner, repo string) (*github.Repository, error)
 	ListOrganizationRepositories(ctx context.Context, org string, page int) ([]*github.Repository, int, error)
@@ -29,58 +32,65 @@ func newGitHubService(client *github.Client) GitHubService { return &githubServi
 
 func (s *githubService) GetRepository(ctx context.Context, owner, repo string) (*github.Repository, error) {
 	repository, _, err := s.client.Repositories.Get(ctx, owner, repo)
-	return repository, err
+	return repository, githubError("get repository", err)
 }
 
 func (s *githubService) ListOrganizationRepositories(ctx context.Context, org string, page int) ([]*github.Repository, int, error) {
 	repositories, response, err := s.client.Repositories.ListByOrg(ctx, org, &ghapi.RepositoryListByOrgOptions{ListOptions: ghapi.ListOptions{Page: page, PerPage: orgReposPerPage}, Type: "all"})
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, githubError("list organization repositories", err)
 	}
 	return repositories, response.NextPage, nil
 }
 
 func (s *githubService) GetRef(ctx context.Context, owner, repo, branch string) (*ghapi.Reference, error) {
 	ref, _, err := s.client.Git.GetRef(ctx, owner, repo, branch)
-	return ref, err
+	return ref, githubError("get ref", err)
 }
 
 func (s *githubService) GetCommit(ctx context.Context, owner, repo, sha string) (*ghapi.Commit, error) {
 	commit, _, err := s.client.Git.GetCommit(ctx, owner, repo, sha)
-	return commit, err
+	return commit, githubError("get commit", err)
 }
 
 func (s *githubService) CreateBlob(ctx context.Context, owner, repo string, blob ghapi.Blob) (*ghapi.Blob, error) {
 	created, _, err := s.client.Git.CreateBlob(ctx, owner, repo, blob)
-	return created, err
+	return created, githubError("create blob", err)
 }
 
 func (s *githubService) CreateTree(ctx context.Context, owner, repo, baseTree string, entries []*ghapi.TreeEntry) (*ghapi.Tree, error) {
 	tree, _, err := s.client.Git.CreateTree(ctx, owner, repo, baseTree, entries)
-	return tree, err
+	return tree, githubError("create tree", err)
 }
 
 func (s *githubService) CreateCommit(ctx context.Context, owner, repo string, commit ghapi.Commit) (*ghapi.Commit, error) {
 	created, _, err := s.client.Git.CreateCommit(ctx, owner, repo, commit, nil)
-	return created, err
+	return created, githubError("create commit", err)
 }
 
 func (s *githubService) CreateRef(ctx context.Context, owner, repo string, ref ghapi.CreateRef) error {
 	_, _, err := s.client.Git.CreateRef(ctx, owner, repo, ref)
-	return err
+	return githubError("create ref", err)
 }
 
 func (s *githubService) UpdateRef(ctx context.Context, owner, repo, branch string, ref ghapi.UpdateRef) error {
 	_, _, err := s.client.Git.UpdateRef(ctx, owner, repo, branch, ref)
-	return err
+	return githubError("update ref", err)
 }
 
 func (s *githubService) ListOpenPullRequests(ctx context.Context, owner, repo, head string) ([]*ghapi.PullRequest, error) {
 	prs, _, err := s.client.PullRequests.List(ctx, owner, repo, &ghapi.PullRequestListOptions{Head: head, State: "open"})
-	return prs, err
+	return prs, githubError("list pull requests", err)
 }
 
 func (s *githubService) CreatePullRequest(ctx context.Context, owner, repo string, pr ghapi.CreatePullRequest) (*ghapi.PullRequest, error) {
 	created, _, err := s.client.PullRequests.Create(ctx, owner, repo, pr)
-	return created, err
+	return created, githubError("create pull request", err)
+}
+
+func githubError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", operation, err)
 }

--- a/pkg/controller/updaterepos/github_service_test.go
+++ b/pkg/controller/updaterepos/github_service_test.go
@@ -94,7 +94,7 @@ func TestCommitChangesCreatesVerifiedAppCommit(t *testing.T) {
 		SHA:          github.Ptr("new-commit"),
 		Verification: &ghapi.SignatureVerification{Verified: github.Ptr(true)},
 	}}
-	controller := newController(nil, service, nil, nil, Param{PRTitle: "chore: pin GitHub Actions"}, nil, nil)
+	controller := newController(service, nil, nil, Param{PRTitle: defaultPRTitle}, nil)
 	repository := &github.Repository{Owner: &ghapi.User{Login: github.Ptr("acme")}, Name: github.Ptr("service")}
 	if err := controller.commitChanges(context.Background(), repository, workdir, "main", false); err != nil {
 		t.Fatal(err)
@@ -117,7 +117,7 @@ func TestCommitChangesRejectsUnverifiedCommit(t *testing.T) {
 		SHA:          github.Ptr("new-commit"),
 		Verification: &ghapi.SignatureVerification{Verified: github.Ptr(false), Reason: github.Ptr("unsigned")},
 	}}
-	controller := newController(nil, service, nil, nil, Param{}, nil, nil)
+	controller := newController(service, nil, nil, Param{}, nil)
 	repository := &github.Repository{Owner: &ghapi.User{Login: github.Ptr("acme")}, Name: github.Ptr("service")}
 	if err := controller.commitChanges(context.Background(), repository, workdir, "main", false); err == nil {
 		t.Fatal("commitChanges succeeded for an unverified commit")
@@ -134,7 +134,7 @@ func TestCommitChangesUpdatesExistingBranch(t *testing.T) {
 		SHA:          github.Ptr("new-commit"),
 		Verification: &ghapi.SignatureVerification{Verified: github.Ptr(true)},
 	}}
-	controller := newController(nil, service, nil, nil, Param{}, nil, nil)
+	controller := newController(service, nil, nil, Param{}, nil)
 	repository := &github.Repository{Owner: &ghapi.User{Login: github.Ptr("acme")}, Name: github.Ptr("service")}
 	if err := controller.commitChanges(context.Background(), repository, workdir, "main", true); err != nil {
 		t.Fatal(err)
@@ -147,7 +147,7 @@ func TestCommitChangesUpdatesExistingBranch(t *testing.T) {
 func TestPullRequestCreatesExpectedRequest(t *testing.T) {
 	t.Parallel()
 	service := &fakeGitHubService{}
-	controller := newController(nil, service, nil, nil, Param{Branch: "pinact/custom", PRTitle: "title", PRBody: "body", Draft: true}, nil, nil)
+	controller := newController(service, nil, nil, Param{Branch: "pinact/custom", PRTitle: "title", PRBody: "body", Draft: true}, nil)
 	repository := &github.Repository{Owner: &ghapi.User{Login: github.Ptr("acme")}, Name: github.Ptr("service")}
 	pr, err := controller.pullRequest(context.Background(), repository, "main", nil)
 	if err != nil {
@@ -164,7 +164,7 @@ func TestPullRequestCreatesExpectedRequest(t *testing.T) {
 func TestExistingPullRequestRejectsDifferentBase(t *testing.T) {
 	t.Parallel()
 	service := &fakeGitHubService{openPRs: []*ghapi.PullRequest{{Base: &ghapi.PullRequestBranch{Ref: github.Ptr("release")}}}}
-	controller := newController(nil, service, nil, nil, Param{}, nil, nil)
+	controller := newController(service, nil, nil, Param{}, nil)
 	repository := &github.Repository{Owner: &ghapi.User{Login: github.Ptr("acme")}, Name: github.Ptr("service")}
 	if _, err := controller.existingPullRequest(context.Background(), repository, "main"); err == nil {
 		t.Fatal("existingPullRequest accepted a pull request with a different base")
@@ -201,7 +201,7 @@ func TestSyncRepositoryDryRunDoesNotMutateGitHub(t *testing.T) {
 	service := &fakeGitHubService{}
 	git := &fakeGitRunner{changed: true}
 	pinner := &fakePinner{hasFiles: true}
-	controller := newController(nil, service, git, pinner, Param{DryRun: true}, nil, nil)
+	controller := newController(service, git, pinner, Param{DryRun: true}, nil)
 	repository := &github.Repository{FullName: github.Ptr("acme/service")}
 	result := controller.syncRepository(context.Background(), slog.Default(), repository, t.TempDir(), "main", Result{Repository: "acme/service"})
 	if result.Status != statusChanged || pinner.calls != 1 || service.createdRef != nil || service.updatedRef != nil || service.createdPR != nil {
@@ -219,7 +219,7 @@ func TestRunFiltersOrganizationRepositories(t *testing.T) {
 	git := &fakeGitRunner{}
 	pinner := &fakePinner{hasFiles: false}
 	var stdout bytes.Buffer
-	controller := newController(nil, service, git, pinner, Param{Organizations: []string{"acme"}, Concurrency: 1, DryRun: true}, &stdout, nil)
+	controller := newController(service, git, pinner, Param{Organizations: []string{"acme"}, Concurrency: 1, DryRun: true}, &stdout)
 	results, err := controller.Run(context.Background(), slog.Default())
 	if err != nil {
 		t.Fatal(err)
@@ -286,7 +286,7 @@ func changedGitWorkdir(t *testing.T) string {
 
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(context.Background(), "git", args...)
 	cmd.Dir = dir
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, output)

--- a/pkg/controller/updaterepos/github_service_test.go
+++ b/pkg/controller/updaterepos/github_service_test.go
@@ -1,0 +1,294 @@
+package updaterepos //nolint:testpackage // tests unexported helpers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	ghapi "github.com/google/go-github/v90/github"
+	"github.com/suzuki-shunsuke/pinact/v4/pkg/github"
+)
+
+type fakeGitHubService struct {
+	commit          *ghapi.Commit
+	createdCommit   ghapi.Commit
+	createdRef      *ghapi.CreateRef
+	updatedRef      *ghapi.UpdateRef
+	createCommitErr error
+	openPRs         []*ghapi.PullRequest
+	createdPR       *ghapi.CreatePullRequest
+	repository      *github.Repository
+	organization    []*github.Repository
+}
+
+func (f *fakeGitHubService) GetRepository(context.Context, string, string) (*github.Repository, error) {
+	return f.repository, nil
+}
+
+func (f *fakeGitHubService) ListOrganizationRepositories(context.Context, string, int) ([]*github.Repository, int, error) {
+	return f.organization, 0, nil
+}
+
+func (f *fakeGitHubService) GetRef(context.Context, string, string, string) (*ghapi.Reference, error) {
+	return &ghapi.Reference{Object: &ghapi.GitObject{SHA: github.Ptr("parent-sha")}}, nil
+}
+
+func (f *fakeGitHubService) GetCommit(context.Context, string, string, string) (*ghapi.Commit, error) {
+	return &ghapi.Commit{Tree: &ghapi.Tree{SHA: github.Ptr("parent-tree")}}, nil
+}
+
+func (f *fakeGitHubService) CreateBlob(_ context.Context, _ string, _ string, blob ghapi.Blob) (*ghapi.Blob, error) {
+	if blob.GetContent() != "updated\n" || blob.GetEncoding() != "utf-8" {
+		return nil, errors.New("unexpected blob")
+	}
+	return &ghapi.Blob{SHA: github.Ptr("blob-sha")}, nil
+}
+
+func (f *fakeGitHubService) CreateTree(_ context.Context, _ string, _ string, baseTree string, entries []*ghapi.TreeEntry) (*ghapi.Tree, error) {
+	if baseTree != "parent-tree" || len(entries) != 1 || entries[0].GetPath() != "workflow.yml" || entries[0].GetSHA() != "blob-sha" {
+		return nil, errors.New("unexpected tree")
+	}
+	return &ghapi.Tree{SHA: github.Ptr("new-tree")}, nil
+}
+
+func (f *fakeGitHubService) CreateCommit(_ context.Context, _ string, _ string, commit ghapi.Commit) (*ghapi.Commit, error) {
+	f.createdCommit = commit
+	if f.createCommitErr != nil {
+		return nil, f.createCommitErr
+	}
+	return f.commit, nil
+}
+
+func (f *fakeGitHubService) CreateRef(_ context.Context, _ string, _ string, ref ghapi.CreateRef) error {
+	f.createdRef = &ref
+	return nil
+}
+
+func (f *fakeGitHubService) UpdateRef(_ context.Context, _ string, _ string, _ string, ref ghapi.UpdateRef) error {
+	f.updatedRef = &ref
+	return nil
+}
+
+func (f *fakeGitHubService) ListOpenPullRequests(context.Context, string, string, string) ([]*ghapi.PullRequest, error) {
+	return f.openPRs, nil
+}
+
+func (f *fakeGitHubService) CreatePullRequest(_ context.Context, _ string, _ string, pr ghapi.CreatePullRequest) (*ghapi.PullRequest, error) {
+	f.createdPR = &pr
+	return &ghapi.PullRequest{HTMLURL: github.Ptr("https://example.com/pr/1")}, nil
+}
+
+func TestCommitChangesCreatesVerifiedAppCommit(t *testing.T) {
+	t.Parallel()
+	workdir := changedGitWorkdir(t)
+	service := &fakeGitHubService{commit: &ghapi.Commit{
+		SHA:          github.Ptr("new-commit"),
+		Verification: &ghapi.SignatureVerification{Verified: github.Ptr(true)},
+	}}
+	controller := newController(nil, service, nil, nil, Param{PRTitle: "chore: pin GitHub Actions"}, nil, nil)
+	repository := &github.Repository{Owner: &ghapi.User{Login: github.Ptr("acme")}, Name: github.Ptr("service")}
+	if err := controller.commitChanges(context.Background(), repository, workdir, "main", false); err != nil {
+		t.Fatal(err)
+	}
+	if service.createdCommit.GetAuthor() != nil || service.createdCommit.GetCommitter() != nil {
+		t.Fatal("CreateCommit received a custom author or committer")
+	}
+	if service.createdCommit.GetMessage() != "chore: pin GitHub Actions" || service.createdCommit.GetTree().GetSHA() != "new-tree" {
+		t.Fatalf("unexpected commit: %#v", service.createdCommit)
+	}
+	if service.createdRef == nil || service.createdRef.GetRef() != "refs/heads/pinact/update-actions" || service.createdRef.GetSHA() != "new-commit" {
+		t.Fatalf("unexpected created ref: %#v", service.createdRef)
+	}
+}
+
+func TestCommitChangesRejectsUnverifiedCommit(t *testing.T) {
+	t.Parallel()
+	workdir := changedGitWorkdir(t)
+	service := &fakeGitHubService{commit: &ghapi.Commit{
+		SHA:          github.Ptr("new-commit"),
+		Verification: &ghapi.SignatureVerification{Verified: github.Ptr(false), Reason: github.Ptr("unsigned")},
+	}}
+	controller := newController(nil, service, nil, nil, Param{}, nil, nil)
+	repository := &github.Repository{Owner: &ghapi.User{Login: github.Ptr("acme")}, Name: github.Ptr("service")}
+	if err := controller.commitChanges(context.Background(), repository, workdir, "main", false); err == nil {
+		t.Fatal("commitChanges succeeded for an unverified commit")
+	}
+	if service.createdRef != nil || service.updatedRef != nil {
+		t.Fatal("commitChanges published an unverified commit")
+	}
+}
+
+func TestCommitChangesUpdatesExistingBranch(t *testing.T) {
+	t.Parallel()
+	workdir := changedGitWorkdir(t)
+	service := &fakeGitHubService{commit: &ghapi.Commit{
+		SHA:          github.Ptr("new-commit"),
+		Verification: &ghapi.SignatureVerification{Verified: github.Ptr(true)},
+	}}
+	controller := newController(nil, service, nil, nil, Param{}, nil, nil)
+	repository := &github.Repository{Owner: &ghapi.User{Login: github.Ptr("acme")}, Name: github.Ptr("service")}
+	if err := controller.commitChanges(context.Background(), repository, workdir, "main", true); err != nil {
+		t.Fatal(err)
+	}
+	if service.createdRef != nil || service.updatedRef == nil || service.updatedRef.GetSHA() != "new-commit" || service.updatedRef.GetForce() {
+		t.Fatalf("unexpected ref update: create=%#v update=%#v", service.createdRef, service.updatedRef)
+	}
+}
+
+func TestPullRequestCreatesExpectedRequest(t *testing.T) {
+	t.Parallel()
+	service := &fakeGitHubService{}
+	controller := newController(nil, service, nil, nil, Param{Branch: "pinact/custom", PRTitle: "title", PRBody: "body", Draft: true}, nil, nil)
+	repository := &github.Repository{Owner: &ghapi.User{Login: github.Ptr("acme")}, Name: github.Ptr("service")}
+	pr, err := controller.pullRequest(context.Background(), repository, "main", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pr.GetHTMLURL() != "https://example.com/pr/1" || service.createdPR == nil {
+		t.Fatalf("unexpected pull request: %#v", pr)
+	}
+	if service.createdPR.GetHead() != "pinact/custom" || service.createdPR.GetBase() != "main" || service.createdPR.GetTitle() != "title" || service.createdPR.GetBody() != "body" || !service.createdPR.GetDraft() {
+		t.Fatalf("unexpected pull request input: %#v", service.createdPR)
+	}
+}
+
+func TestExistingPullRequestRejectsDifferentBase(t *testing.T) {
+	t.Parallel()
+	service := &fakeGitHubService{openPRs: []*ghapi.PullRequest{{Base: &ghapi.PullRequestBranch{Ref: github.Ptr("release")}}}}
+	controller := newController(nil, service, nil, nil, Param{}, nil, nil)
+	repository := &github.Repository{Owner: &ghapi.User{Login: github.Ptr("acme")}, Name: github.Ptr("service")}
+	if _, err := controller.existingPullRequest(context.Background(), repository, "main"); err == nil {
+		t.Fatal("existingPullRequest accepted a pull request with a different base")
+	}
+}
+
+type fakeGitRunner struct {
+	changed bool
+	calls   [][]string
+}
+
+func (r *fakeGitRunner) Run(_ context.Context, _ string, _ io.Writer, _ io.Writer, args ...string) error {
+	r.calls = append(r.calls, args)
+	return nil
+}
+
+func (r *fakeGitRunner) Changed(context.Context, string) (bool, error) { return r.changed, nil }
+
+func (r *fakeGitRunner) ChangedFiles(context.Context, string) ([]string, error) { return nil, nil }
+
+type fakePinner struct {
+	hasFiles bool
+	err      error
+	calls    int
+}
+
+func (p *fakePinner) Pin(context.Context, *slog.Logger, string) (bool, error) {
+	p.calls++
+	return p.hasFiles, p.err
+}
+
+func TestSyncRepositoryDryRunDoesNotMutateGitHub(t *testing.T) {
+	t.Parallel()
+	service := &fakeGitHubService{}
+	git := &fakeGitRunner{changed: true}
+	pinner := &fakePinner{hasFiles: true}
+	controller := newController(nil, service, git, pinner, Param{DryRun: true}, nil, nil)
+	repository := &github.Repository{FullName: github.Ptr("acme/service")}
+	result := controller.syncRepository(context.Background(), slog.Default(), repository, t.TempDir(), "main", Result{Repository: "acme/service"})
+	if result.Status != statusChanged || pinner.calls != 1 || service.createdRef != nil || service.updatedRef != nil || service.createdPR != nil {
+		t.Fatalf("unexpected dry-run result: %#v", result)
+	}
+}
+
+func TestRunFiltersOrganizationRepositories(t *testing.T) {
+	t.Parallel()
+	service := &fakeGitHubService{organization: []*github.Repository{
+		{FullName: github.Ptr("acme/active")},
+		{FullName: github.Ptr("acme/fork"), Fork: github.Ptr(true)},
+		{FullName: github.Ptr("acme/archived"), Archived: github.Ptr(true)},
+	}}
+	git := &fakeGitRunner{}
+	pinner := &fakePinner{hasFiles: false}
+	var stdout bytes.Buffer
+	controller := newController(nil, service, git, pinner, Param{Organizations: []string{"acme"}, Concurrency: 1, DryRun: true}, &stdout, nil)
+	results, err := controller.Run(context.Background(), slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Repository != "acme/active" || results[0].Status != statusSkipped || pinner.calls != 1 {
+		t.Fatalf("unexpected results: %#v", results)
+	}
+	if stdout.String() != "acme/active: skipped\n" {
+		t.Fatalf("unexpected output: %q", stdout.String())
+	}
+}
+
+func TestGitHubServiceCreateCommitOmitsIdentity(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v3/repos/acme/service/git/commits" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := body["author"]; ok {
+			t.Fatal("commit request includes author")
+		}
+		if _, ok := body["committer"]; ok {
+			t.Fatal("commit request includes committer")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"sha":"commit","verification":{"verified":true}}`))
+	}))
+	defer server.Close()
+	client, err := github.NewWithBaseURL(context.Background(), server.URL+"/api/v3/", "token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := newGitHubService(client)
+	commit, err := service.CreateCommit(context.Background(), "acme", "service", ghapi.Commit{Message: github.Ptr("message"), Tree: &ghapi.Tree{SHA: github.Ptr("tree")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !commit.GetVerification().GetVerified() {
+		t.Fatal("commit response was not decoded")
+	}
+}
+
+func changedGitWorkdir(t *testing.T) string {
+	t.Helper()
+	workdir := t.TempDir()
+	runGit(t, workdir, "init", "--quiet")
+	runGit(t, workdir, "config", "user.name", "test")
+	runGit(t, workdir, "config", "user.email", "test@example.com")
+	path := filepath.Join(workdir, "workflow.yml")
+	if err := os.WriteFile(path, []byte("original\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, workdir, "add", "workflow.yml")
+	runGit(t, workdir, "commit", "--quiet", "-m", "initial")
+	if err := os.WriteFile(path, []byte("updated\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return workdir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+}

--- a/pkg/controller/updaterepos/local_services.go
+++ b/pkg/controller/updaterepos/local_services.go
@@ -1,0 +1,59 @@
+package updaterepos
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os/exec"
+	"strings"
+)
+
+type GitRunner interface {
+	Run(ctx context.Context, dir string, stdout, stderr io.Writer, args ...string) error
+	Changed(ctx context.Context, dir string) (bool, error)
+	ChangedFiles(ctx context.Context, dir string) ([]string, error)
+}
+
+type Pinner interface {
+	Pin(ctx context.Context, logger *slog.Logger, workdir string) (bool, error)
+}
+
+type localGitRunner struct{ controller *Controller }
+
+func (r localGitRunner) Run(ctx context.Context, dir string, stdout, stderr io.Writer, args ...string) error {
+	return r.controller.executeGit(ctx, dir, stdout, stderr, args...)
+}
+
+func (r localGitRunner) Changed(ctx context.Context, workdir string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "diff", "--quiet")
+	cmd.Dir = workdir
+	err := cmd.Run()
+	if err == nil {
+		return false, nil
+	}
+	var exit *exec.ExitError
+	if errors.As(err, &exit) && exit.ExitCode() == 1 {
+		return true, nil
+	}
+	return false, fmt.Errorf("check git diff: %w", err)
+}
+
+func (r localGitRunner) ChangedFiles(ctx context.Context, workdir string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "diff", "--name-only")
+	cmd.Dir = workdir
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("list changed files: %w", err)
+	}
+	return strings.Fields(stdout.String()), nil
+}
+
+type controllerPinner struct{ controller *Controller }
+
+func (p controllerPinner) Pin(ctx context.Context, logger *slog.Logger, workdir string) (bool, error) {
+	return p.controller.pin(ctx, logger, workdir)
+}

--- a/pkg/di/ghes.go
+++ b/pkg/di/ghes.go
@@ -8,11 +8,19 @@ import (
 	"github.com/suzuki-shunsuke/pinact/v4/pkg/github"
 )
 
-// setupGHESServices creates GitHub API services with GHES (GitHub Enterprise Server) support.
+type GHESServices struct {
+	RepoService *github.RepositoriesServiceImpl
+	GitService  *github.GitServiceImpl
+}
+
+// SetupGHESServices creates GitHub API services with GHES (GitHub Enterprise Server) support.
 // It configures a ClientResolver that routes API requests to either GHES or github.com
 // based on the configuration. When GHES is enabled with fallback, repositories are first
 // checked on GHES and fall back to github.com if not found.
-func setupGHESServices(ctx context.Context, gh *github.Client, cfg *config.Config, flags *Flags, token string) (*ghesServices, error) {
+func SetupGHESServices(ctx context.Context, gh *github.Client, cfg *config.Config, flags *Flags, token string) (*GHESServices, error) {
+	if flags == nil {
+		flags = &Flags{}
+	}
 	ghesConfig := cfg.GHES
 	if ghesConfig == nil {
 		ghesConfig = flags.GHESFromEnv()
@@ -57,8 +65,8 @@ func setupGHESServices(ctx context.Context, gh *github.Client, cfg *config.Confi
 	}
 	gitService.SetResolver(resolver)
 
-	return &ghesServices{
-		repoService: repoService,
-		gitService:  gitService,
+	return &GHESServices{
+		RepoService: repoService,
+		GitService:  gitService,
 	}, nil
 }

--- a/pkg/di/run.go
+++ b/pkg/di/run.go
@@ -24,11 +24,6 @@ import (
 // formatSarif is the only -format value supported by pinact.
 const formatSarif = "sarif"
 
-type ghesServices struct {
-	repoService *github.RepositoriesServiceImpl
-	gitService  *github.GitServiceImpl
-}
-
 // Run executes the main run command logic.
 // It configures logging, processes GitHub Actions context, parses includes/excludes,
 // sets up the controller, and executes the pinning operation.
@@ -66,12 +61,12 @@ func Run(ctx context.Context, logger *slogutil.Logger, flags *Flags, secrets *Se
 		}
 		param.DiffFilter = df
 	}
-	services, err := setupGHESServices(ctx, gh, cfg, flags, secrets.GHESToken)
+	services, err := SetupGHESServices(ctx, gh, cfg, flags, secrets.GHESToken)
 	if err != nil {
 		return err
 	}
 
-	ctrl := run.New(services.repoService, services.gitService, fs, cfg, param)
+	ctrl := run.New(services.RepoService, services.GitService, fs, cfg, param)
 	return ctrl.Run(ctx, logger.Logger) //nolint:wrapcheck
 }
 

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -48,6 +48,23 @@ func New(ctx context.Context, logger *slog.Logger, token string, keyringEnabled 
 	return client, nil
 }
 
+// Token resolves the GitHub token used by pinact. Callers that need to
+// authenticate a Git transport can use the returned access token.
+func Token(_ context.Context, logger *slog.Logger, token string, keyringEnabled bool) (string, error) {
+	ts, err := getTokenSourceForGitHub(logger, token, keyringEnabled)
+	if err != nil {
+		return "", fmt.Errorf("get token source for GitHub: %w", err)
+	}
+	if ts == nil {
+		return "", nil
+	}
+	t, err := ts.Token()
+	if err != nil {
+		return "", fmt.Errorf("get GitHub token: %w", err)
+	}
+	return t.AccessToken, nil
+}
+
 // Ptr returns a pointer to the provided value.
 // This is a convenience function that delegates to new for
 // creating pointers to values, commonly needed for GitHub API structs.


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/suzuki-shunsuke/pinact/issues/1685
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

<!-- Please write the description here -->

Add `pinact update-repos` to pin GitHub Actions across repositories and open a pull request when files change.

This is meant for organization-wide pinning without per-repo scripting. The command reuses `pkg/controller/run`, supports `--org` / `--repo` selection, `--dry-run`, and JSON output. Commits go through the Git Data API so GitHub App installation tokens produce signed commits.

Closes #1685

_This pull request was drafted with AI assistance and reviewed before opening._