### PR TITLE
fix: disable exhaustruct_v5

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - err113
     - exhaustive
     - exhaustruct
+    - exhaustruct_v5
     - godot
     - godox
     - ireturn


### PR DESCRIPTION
Fixes the CI failure on the Renovate PR that this branches from, so that golangci-lint v2.13.0 can be merged.

golangci-lint v2.13.0 replaced `exhaustruct` with `exhaustruct_v5` (it bumped `dev.gaijin.team/go/exhaustruct` from v4 to v5). This config uses `default: all`, so the new name is enabled automatically while only the old `exhaustruct` sits in `disable`. That is why lint suddenly fails on struct literals that were fine before.

Adding `exhaustruct_v5` to `disable` keeps the linter off, the same way `wsl` and `wsl_v5` are both listed today.

Verified locally with golangci-lint v2.13.0 on three repositories. Every reported issue was `exhaustruct_v5`, and the change takes them to zero:

| repo | before | after |
|---|---|---|
| suzuki-shunsuke/ci-info | 18 issues | 0 issues |
| suzuki-shunsuke/tfcmt | 50 issues | 0 issues |
| aquaproj/aqua-registry-updater | 28 issues | 0 issues |

Base is the Renovate branch, so merging this puts the fix on it and leaves that PR to merge into the default branch as usual.
