### PR TITLE
fix: describe every configuration field in the JSON Schema and correct required

### DIFF
--- a/json-schema/pinact.json
+++ b/json-schema/pinact.json
@@ -7,7 +7,7 @@
       "properties": {
         "expr": {
           "type": "string",
-          "description": "A boolean expression evaluated against the action, such as ActionName matches 'suzuki-shunsuke/.*'. It is required. See https://expr-lang.org/docs/language-definition"
+          "description": "A boolean expression evaluated against the action, such as ActionName matches 'suzuki-shunsuke/.*'. See https://expr-lang.org/docs/language-definition"
         }
       },
       "additionalProperties": false,
@@ -24,7 +24,7 @@
             2,
             3
           ],
-          "description": "The schema version of the configuration file. It is required. The latest version is 3. Version 2 is abandoned, so run 'pinact migrate' to migrate an old configuration file to the latest version"
+          "description": "The schema version of the configuration file. The latest version is 3. Version 2 is abandoned, so run 'pinact migrate' to migrate an old configuration file to the latest version"
         },
         "files": {
           "items": {
@@ -70,7 +70,7 @@
       "properties": {
         "pattern": {
           "type": "string",
-          "description": "A glob pattern of target files, such as '.github/workflows/*.yaml'. It is required. Go's path/filepath#Glob is used, so the pattern follows its syntax"
+          "description": "A glob pattern of target files, such as '.github/workflows/*.yaml'. Go's path/filepath#Glob is used, so the pattern follows its syntax"
         }
       },
       "additionalProperties": false,
@@ -97,11 +97,11 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "A regular expression of ignored actions and reusable workflows. It is required. It must match the action name exactly, so 'actions/.*' matches 'actions/checkout' while 'actions' matches nothing"
+          "description": "A regular expression of ignored actions and reusable workflows. It must match the action name exactly, so 'actions/.*' matches 'actions/checkout' while 'actions' matches nothing"
         },
         "ref": {
           "type": "string",
-          "description": "A regular expression of ignored action versions, which are a branch, a tag, or a commit hash. It is required. It must match the version exactly, so 'main' doesn't match 'malicious-main'"
+          "description": "A regular expression of ignored action versions, which are a branch, a tag, or a commit hash. It must match the version exactly, so 'main' doesn't match 'malicious-main'"
         }
       },
       "additionalProperties": false,
@@ -141,7 +141,7 @@
           },
           "type": "array",
           "minItems": 1,
-          "description": "Match conditions. It is required. The rule matches if any condition evaluates to true"
+          "description": "Match conditions. The rule matches if any condition evaluates to true"
         }
       },
       "additionalProperties": false,

--- a/json-schema/pinact.json
+++ b/json-schema/pinact.json
@@ -7,7 +7,7 @@
       "properties": {
         "expr": {
           "type": "string",
-          "description": "A boolean expression. See https://expr-lang.org/docs/language-definition"
+          "description": "A boolean expression evaluated against the action, such as ActionName matches 'suzuki-shunsuke/.*'. It is required. See https://expr-lang.org/docs/language-definition"
         }
       },
       "additionalProperties": false,
@@ -23,14 +23,15 @@
           "enum": [
             2,
             3
-          ]
+          ],
+          "description": "The schema version of the configuration file. It is required. The latest version is 3. Version 2 is abandoned, so run 'pinact migrate' to migrate an old configuration file to the latest version"
         },
         "files": {
           "items": {
             "$ref": "#/$defs/File"
           },
           "type": "array",
-          "description": "Target files. If files are passed via positional command line arguments"
+          "description": "Target files. If files are passed via positional command line arguments, this is ignored"
         },
         "ignore_actions": {
           "items": {
@@ -49,7 +50,7 @@
         },
         "min_age": {
           "$ref": "#/$defs/MinAge",
-          "description": "Default min-age settings. value is the threshold in days; always opts every run into the passive audit. rules can override value per action"
+          "description": "Default min-age settings. value is the threshold in days, always opts every run into the passive audit, and rules can override value per action"
         },
         "rules": {
           "items": {
@@ -62,13 +63,14 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "min_age"
+        "version"
       ]
     },
     "File": {
       "properties": {
         "pattern": {
-          "type": "string"
+          "type": "string",
+          "description": "A glob pattern of target files, such as '.github/workflows/*.yaml'. It is required. Go's path/filepath#Glob is used, so the pattern follows its syntax"
         }
       },
       "additionalProperties": false,
@@ -81,11 +83,11 @@
       "properties": {
         "api_url": {
           "type": "string",
-          "description": "API URL of the GHES instance (e.g. https://ghes.example.com)"
+          "description": "API URL of the GHES instance, such as https://ghes.example.com. GHES support is enabled by setting this field"
         },
         "fallback": {
           "type": "boolean",
-          "description": "Whether to fallback to github.com when a repository is not found on GHES. Default is false"
+          "description": "Fall back to github.com when a repository is not found on GHES. The default value is false"
         }
       },
       "additionalProperties": false,
@@ -94,27 +96,30 @@
     "IgnoreAction": {
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "A regular expression of ignored actions and reusable workflows. It is required. It must match the action name exactly, so 'actions/.*' matches 'actions/checkout' while 'actions' matches nothing"
         },
         "ref": {
-          "type": "string"
+          "type": "string",
+          "description": "A regular expression of ignored action versions, which are a branch, a tag, or a commit hash. It is required. It must match the version exactly, so 'main' doesn't match 'malicious-main'"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "name"
+        "name",
+        "ref"
       ]
     },
     "MinAge": {
       "properties": {
         "value": {
           "type": "integer",
-          "description": "Default min-age threshold in days"
+          "description": "The default min-age threshold in days. rules[].min_age and the --min-age flag override this value"
         },
         "always": {
           "type": "boolean",
-          "description": "When true every run performs the passive min-age audit. Default false"
+          "description": "Perform the passive min-age audit on every run, even without the --verify-min-age flag. The default value is false"
         }
       },
       "additionalProperties": false,
@@ -124,22 +129,26 @@
       "properties": {
         "ignore": {
           "type": "boolean",
-          "description": "If true pinact skips pin/update/error for the matched action"
+          "description": "If true, pinact skips pin/update/error for the matched action"
         },
         "min_age": {
           "type": "integer",
-          "description": "Override the min-age threshold (in days) for the matched action. 0 disables the check for the action"
+          "description": "Override the min-age threshold, in days, for the matched action. 0 disables the check for the action"
         },
         "conditions": {
           "items": {
             "$ref": "#/$defs/Condition"
           },
           "type": "array",
-          "description": "Match conditions. The rule matches if any condition evaluates to true"
+          "minItems": 1,
+          "description": "Match conditions. It is required. The rule matches if any condition evaluates to true"
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "required": [
+        "conditions"
+      ]
     }
   }
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,7 +31,7 @@ const (
 )
 
 type Config struct {
-	Version       int             `json:"version" jsonschema:"enum=2,enum=3" jsonschema_description:"The schema version of the configuration file. It is required. The latest version is 3. Version 2 is abandoned, so run 'pinact migrate' to migrate an old configuration file to the latest version"`
+	Version       int             `json:"version" jsonschema:"enum=2,enum=3" jsonschema_description:"The schema version of the configuration file. The latest version is 3. Version 2 is abandoned, so run 'pinact migrate' to migrate an old configuration file to the latest version"`
 	Files         []*File         `json:"files,omitempty" jsonschema_description:"Target files. If files are passed via positional command line arguments, this is ignored"`
 	IgnoreActions []*IgnoreAction `json:"ignore_actions,omitempty" yaml:"ignore_actions" jsonschema_description:"Actions and reusable workflows that pinact ignores. For new configurations consider using 'rules' with 'ignore: true' for more flexibility"`
 	GHES          *GHES           `json:"ghes,omitempty" yaml:"ghes" jsonschema_description:"GitHub Enterprise Server configuration"`
@@ -65,7 +65,7 @@ type GHES struct {
 }
 
 type File struct {
-	Pattern string `json:"pattern" jsonschema_description:"A glob pattern of target files, such as '.github/workflows/*.yaml'. It is required. Go's path/filepath#Glob is used, so the pattern follows its syntax"`
+	Pattern string `json:"pattern" jsonschema_description:"A glob pattern of target files, such as '.github/workflows/*.yaml'. Go's path/filepath#Glob is used, so the pattern follows its syntax"`
 }
 
 var (
@@ -118,8 +118,8 @@ func (f *File) Init() error {
 }
 
 type IgnoreAction struct {
-	Name       string `json:"name" jsonschema_description:"A regular expression of ignored actions and reusable workflows. It is required. It must match the action name exactly, so 'actions/.*' matches 'actions/checkout' while 'actions' matches nothing"`
-	Ref        string `json:"ref" jsonschema_description:"A regular expression of ignored action versions, which are a branch, a tag, or a commit hash. It is required. It must match the version exactly, so 'main' doesn't match 'malicious-main'"`
+	Name       string `json:"name" jsonschema_description:"A regular expression of ignored actions and reusable workflows. It must match the action name exactly, so 'actions/.*' matches 'actions/checkout' while 'actions' matches nothing"`
+	Ref        string `json:"ref" jsonschema_description:"A regular expression of ignored action versions, which are a branch, a tag, or a commit hash. It must match the version exactly, so 'main' doesn't match 'malicious-main'"`
 	nameRegexp *regexp.Regexp
 	refRegexp  *regexp.Regexp
 }
@@ -172,13 +172,13 @@ func (ia *IgnoreAction) initRef() error {
 type Rule struct {
 	Ignore     *bool        `json:"ignore,omitempty" jsonschema_description:"If true, pinact skips pin/update/error for the matched action"`
 	MinAge     *int         `json:"min_age,omitempty" yaml:"min_age" jsonschema_description:"Override the min-age threshold, in days, for the matched action. 0 disables the check for the action"`
-	Conditions []*Condition `json:"conditions" jsonschema:"minItems=1" jsonschema_description:"Match conditions. It is required. The rule matches if any condition evaluates to true"`
+	Conditions []*Condition `json:"conditions" jsonschema:"minItems=1" jsonschema_description:"Match conditions. The rule matches if any condition evaluates to true"`
 }
 
 // Condition is one of the expressions in a rule. The rule matches when at
 // least one of its conditions evaluates to true.
 type Condition struct {
-	Expr    string      `json:"expr" jsonschema_description:"A boolean expression evaluated against the action, such as ActionName matches 'suzuki-shunsuke/.*'. It is required. See https://expr-lang.org/docs/language-definition"`
+	Expr    string      `json:"expr" jsonschema_description:"A boolean expression evaluated against the action, such as ActionName matches 'suzuki-shunsuke/.*'. See https://expr-lang.org/docs/language-definition"`
 	program *vm.Program // cached compiled program, populated by Init
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,13 +31,13 @@ const (
 )
 
 type Config struct {
-	Version       int             `json:"version,omitempty" jsonschema:"enum=2,enum=3"`
-	Files         []*File         `json:"files,omitempty" jsonschema:"description=Target files. If files are passed via positional command line arguments, this is ignored"`
-	IgnoreActions []*IgnoreAction `json:"ignore_actions,omitempty" yaml:"ignore_actions" jsonschema:"description=Actions and reusable workflows that pinact ignores. For new configurations consider using 'rules' with 'ignore: true' for more flexibility"`
-	GHES          *GHES           `json:"ghes,omitempty" yaml:"ghes" jsonschema:"description=GitHub Enterprise Server configuration"`
-	Separator     string          `json:"separator,omitempty" jsonschema:"description=Separator between version and tag comment. Default is ' # '"`
-	MinAge        *MinAge         `json:"min_age,omitzero" yaml:"min_age" jsonschema:"description=Default min-age settings. value is the threshold in days; always opts every run into the passive audit. rules can override value per action"`
-	Rules         []*Rule         `json:"rules,omitempty" jsonschema:"description=Per-action setting overrides. Later matching rules override earlier ones at the field level"`
+	Version       int             `json:"version" jsonschema:"enum=2,enum=3" jsonschema_description:"The schema version of the configuration file. It is required. The latest version is 3. Version 2 is abandoned, so run 'pinact migrate' to migrate an old configuration file to the latest version"`
+	Files         []*File         `json:"files,omitempty" jsonschema_description:"Target files. If files are passed via positional command line arguments, this is ignored"`
+	IgnoreActions []*IgnoreAction `json:"ignore_actions,omitempty" yaml:"ignore_actions" jsonschema_description:"Actions and reusable workflows that pinact ignores. For new configurations consider using 'rules' with 'ignore: true' for more flexibility"`
+	GHES          *GHES           `json:"ghes,omitempty" yaml:"ghes" jsonschema_description:"GitHub Enterprise Server configuration"`
+	Separator     string          `json:"separator,omitempty" jsonschema_description:"Separator between version and tag comment. Default is ' # '"`
+	MinAge        *MinAge         `json:"min_age,omitempty" yaml:"min_age" jsonschema_description:"Default min-age settings. value is the threshold in days, always opts every run into the passive audit, and rules can override value per action"`
+	Rules         []*Rule         `json:"rules,omitempty" jsonschema_description:"Per-action setting overrides. Later matching rules override earlier ones at the field level"`
 }
 
 // MinAge controls both the threshold and whether the passive audit auto-runs.
@@ -55,17 +55,17 @@ type Config struct {
 // value when merging a project config on top of a global config: a project
 // that omits min_age.always must not clobber a global true with a false.
 type MinAge struct {
-	Value  *int  `json:"value,omitempty" jsonschema:"description=Default min-age threshold in days"`
-	Always *bool `json:"always,omitempty" jsonschema:"description=When true every run performs the passive min-age audit. Default false"`
+	Value  *int  `json:"value,omitempty" jsonschema_description:"The default min-age threshold in days. rules[].min_age and the --min-age flag override this value"`
+	Always *bool `json:"always,omitempty" jsonschema_description:"Perform the passive min-age audit on every run, even without the --verify-min-age flag. The default value is false"`
 }
 
 type GHES struct {
-	APIURL   string `json:"api_url,omitempty" yaml:"api_url" jsonschema:"description=API URL of the GHES instance (e.g. https://ghes.example.com)"`
-	Fallback bool   `json:"fallback,omitempty" yaml:"fallback" jsonschema:"description=Whether to fallback to github.com when a repository is not found on GHES. Default is false"`
+	APIURL   string `json:"api_url,omitempty" yaml:"api_url" jsonschema_description:"API URL of the GHES instance, such as https://ghes.example.com. GHES support is enabled by setting this field"`
+	Fallback bool   `json:"fallback,omitempty" yaml:"fallback" jsonschema_description:"Fall back to github.com when a repository is not found on GHES. The default value is false"`
 }
 
 type File struct {
-	Pattern string `json:"pattern"`
+	Pattern string `json:"pattern" jsonschema_description:"A glob pattern of target files, such as '.github/workflows/*.yaml'. It is required. Go's path/filepath#Glob is used, so the pattern follows its syntax"`
 }
 
 var (
@@ -118,8 +118,8 @@ func (f *File) Init() error {
 }
 
 type IgnoreAction struct {
-	Name       string `json:"name"`
-	Ref        string `json:"ref,omitempty"`
+	Name       string `json:"name" jsonschema_description:"A regular expression of ignored actions and reusable workflows. It is required. It must match the action name exactly, so 'actions/.*' matches 'actions/checkout' while 'actions' matches nothing"`
+	Ref        string `json:"ref" jsonschema_description:"A regular expression of ignored action versions, which are a branch, a tag, or a commit hash. It is required. It must match the version exactly, so 'main' doesn't match 'malicious-main'"`
 	nameRegexp *regexp.Regexp
 	refRegexp  *regexp.Regexp
 }
@@ -170,15 +170,15 @@ func (ia *IgnoreAction) initRef() error {
 // in declaration order: later rules override earlier ones, but only for fields
 // they explicitly set.
 type Rule struct {
-	Ignore     *bool        `json:"ignore,omitempty" jsonschema:"description=If true pinact skips pin/update/error for the matched action"`
-	MinAge     *int         `json:"min_age,omitempty" yaml:"min_age" jsonschema:"description=Override the min-age threshold (in days) for the matched action. 0 disables the check for the action"`
-	Conditions []*Condition `json:"conditions,omitempty" jsonschema:"description=Match conditions. The rule matches if any condition evaluates to true"`
+	Ignore     *bool        `json:"ignore,omitempty" jsonschema_description:"If true, pinact skips pin/update/error for the matched action"`
+	MinAge     *int         `json:"min_age,omitempty" yaml:"min_age" jsonschema_description:"Override the min-age threshold, in days, for the matched action. 0 disables the check for the action"`
+	Conditions []*Condition `json:"conditions" jsonschema:"minItems=1" jsonschema_description:"Match conditions. It is required. The rule matches if any condition evaluates to true"`
 }
 
 // Condition is one of the expressions in a rule. The rule matches when at
 // least one of its conditions evaluates to true.
 type Condition struct {
-	Expr    string      `json:"expr" jsonschema:"description=A boolean expression. See https://expr-lang.org/docs/language-definition"`
+	Expr    string      `json:"expr" jsonschema_description:"A boolean expression evaluated against the action, such as ActionName matches 'suzuki-shunsuke/.*'. It is required. See https://expr-lang.org/docs/language-definition"`
 	program *vm.Program // cached compiled program, populated by Init
 }
 


### PR DESCRIPTION
The JSON Schema of the configuration file left several fields undescribed and required the wrong ones. This fills in the descriptions, following [ghtkn-go-sdk's config package](https://github.com/suzuki-shunsuke/ghtkn-go-sdk/blob/main/ghtkn/config/config.go), and makes `required` match what pinact actually accepts.

Only `pkg/config/config.go` is edited; `json-schema/pinact.json` is regenerated with `cmdx js`.

## Descriptions

`version`, `files[].pattern`, `ignore_actions[].name`, and `ignore_actions[].ref` had no description at all, so an editor completing the configuration file said nothing about them. The new descriptions say what pinact does with the field, which flag overrides it, and what a regular expression has to match, such as that `ref: main` doesn't match `malicious-main`. The existing descriptions are kept, with wording aligned to the same style.

The tag moves from `jsonschema:"description=..."` to `jsonschema_description:"..."`, which is what ghtkn-go-sdk uses. The former splits the tag on commas, and `files` was already losing text to it:

```diff
-"description": "Target files. If files are passed via positional command line arguments"
+"description": "Target files. If files are passed via positional command line arguments, this is ignored"
```

## `required`

| Type | Before | After |
| --- | --- | --- |
| Config | `min_age` | `version` |
| IgnoreAction | `name` | `name`, `ref` |
| Rule | | `conditions` |
| File | `pattern` | `pattern` |
| Condition | `expr` | `expr` |

- `min_age` was required because invopop/jsonschema doesn't recognize `omitzero` and took the field for a required one. Every configuration file without `min_age` was reported as invalid, which is the worst of these: it is a false positive on a valid file. The tag is now `omitempty`, which behaves the same for a pointer field.
- `version`, `ignore_actions[].ref`, and `rules[].conditions` are required by pinact, which fails without them, but the schema didn't say so.
- `rules[].conditions` also gets `minItems: 1`, because pinact rejects an empty list with "rule must have at least one condition".

`ghes.api_url` is left optional on purpose. `GHES.Validate` rejects an empty one, but `pkg/di/ghes.go` merges the environment variables into the block first, so a configuration file that ships `ghes.fallback` and takes the API URL from the environment is valid.

## Verification

`cmdx v`, `cmdx t`, and `golangci-lint run` pass. The schema is regenerated by `cmdx js`, so it matches the structs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)