### PR TITLE
docs: fix anchor links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ $ pinact run
 ## Features
 
 1. Pin GitHub Actions and Reusable Workflows
-1. [Check if actions are pinned without editing files](#just-validation--check--fixfalse)
-1. [Offline check without GitHub API](#offline-check--no-api)
-1. [Update actions](#update-actions--update) with a [minimum release age](#minimum-release-age-cooldown--min-age--verify-min-age)
-1. [Verify version comments](docs/codes/001.md) ([`--verify-comment`](#verify-version-comments--verify-comment--verify--v))
+1. [Check if actions are pinned without editing files](#just-validation---check---fixfalse)
+1. [Offline check without GitHub API](#offline-check---no-api)
+1. [Update actions](#update-actions---update) with a [minimum release age](#minimum-release-age-cooldown---min-age---verify-min-age)
+1. [Verify version comments](docs/codes/001.md) ([`--verify-comment`](#verify-version-comments---verify-comment---verify---v))
 1. [Require a version comment on SHA-pinned actions](docs/codes/005.md)
-1. [Verify if actions meet the minimum release age](#minimum-release-age-cooldown--min-age)
-1. [Pin branches](#pin-branches--branch-to-tag)
+1. [Verify if actions meet the minimum release age](#minimum-release-age-cooldown---min-age)
+1. [Pin branches](#pin-branches---branch-to-tag)
 1. [Include and exclude specific actions](#include-and-exclude-specific-actions)
 1. [Generate SARIF](#sarif). This is useful to create reviews using [reviewdog](#reviewdog)
 1. [Read GitHub access token via keyrings or ghtkn](#github-access-token)


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)

I looked at the README and noticed that the anchor links in the table of features do not work. This PR fixes them. Basically, a CLI arg like `use the --min-age arg` in the heading needs a third `-`: `use-the---min-age-arg`.
